### PR TITLE
bump to v1.5.0

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -8,6 +8,7 @@
 
 #####################################################################################
 
+export BASHBONE_WORKINGDIR="$PWD"
 export BASHBONE_DIR="$(dirname "$(readlink -e "${BASH_SOURCE[0]}")")"
 export BASHBONE_VERSION=$(source "$BASHBONE_DIR/lib/version.sh"; echo $version)
 export BASHBONE_TOOLSDIR="${BASHBONE_TOOLSDIR:-$(dirname "$BASHBONE_DIR")}" # export to not override if previously defined
@@ -241,7 +242,7 @@ function _bashbone_trace(){
 				line=$((line+3))
 				cmd=$(declare -f $fun | awk -v l=$line '{ if(NR>=l){if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{print o$0; exit}}else{if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{o=""}}}' | sed -E -e 's/\s+/ /g' -e 's/(^\s+|\s+$)//g')
 			else
-				cmd=$(awk -v l=$line '{ if(NR>=l){if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{print o$0; exit}}else{if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{o=""}}}' "$src" | sed -E -e 's/\s+/ /g' -e 's/(^\s+|\s+$)//g')
+				cmd=$(awk -v l=$line '{ if(NR>=l){if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{print o$0; exit}}else{if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{o=""}}}' "$BASHBONE_WORKINGDIR/$src" | sed -E -e 's/\s+/ /g' -e 's/(^\s+|\s+$)//g')
 			fi
 			echo ":ERROR: ${BASHBONE_ERROR:+$BASHBONE_ERROR }in ${src:-shell} (function: ${fun:-main}) @ line $line: $cmd" >&2
 		fi
@@ -269,7 +270,7 @@ function _bashbone_trace_interactive(){
 		if [[ $line -eq 1 ]]; then
 			echo ":ERROR: ${BASHBONE_ERROR:+$BASHBONE_ERROR }in ${src:-shell} (function: ${fun:-main} @ line $l)" >> "$o"
 		else
-			cmd=$(awk -v l=$l '{ if(NR>=l){if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{print o$0; exit}}else{if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{o=""}}}' "$src" | sed -E -e 's/\s+/ /g' -e 's/(^\s+|\s+$)//g')
+			cmd=$(awk -v l=$l '{ if(NR>=l){if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{print o$0; exit}}else{if($0~/\s\\\s*$/){o=o""gensub(/\\\s*$/,"",1,$0)}else{o=""}}}' "$BASHBONE_WORKINGDIR/$src" | sed -E -e 's/\s+/ /g' -e 's/(^\s+|\s+$)//g')
 			echo ":ERROR: ${BASHBONE_ERROR:+$BASHBONE_ERROR }in ${src:-shell} (function: ${fun:-main}) @ line $l: $cmd" >> "$o"
 		fi
 	done

--- a/activate.sh
+++ b/activate.sh
@@ -364,8 +364,8 @@ function _bashbone_wrapper(){
 		read -r f_bashbone_wrapper l_bashbone_wrapper s_bashbone_wrapper < <(declare -F $BASHBONE_FUNCNAME) || true
 		if [[ "$s_bashbone_wrapper" == "$BASHBONE_DIR/lib/"* ]]; then
 			[[ "$BASHBONE_FUNCNAME" == commander::* || "$BASHBONE_FUNCNAME" == progress::* ]] || BASHBONE_LEGACY=true
-		else
-			BASHBONE_LEGACY=false
+		# else
+		# 	BASHBONE_LEGACY=false
 		fi
 		local BASHBONE_BPID=$BASHPID
 		local BASHBONE_CLEANUP="$(command mktemp -p "$BASHBONE_TMPDIR" cleanup.XXXXXXXXXX.sh)"

--- a/config/m6aviewer.url
+++ b/config/m6aviewer.url
@@ -1,1 +1,1 @@
-http://dna2.leeds.ac.uk/m6a/m6aViewer_1_6_1.jar
+https://gitlab.leibniz-fli.de/kriege/m6aviewer/-/raw/main/m6aviewer.jar

--- a/lib/alignment_1.sh
+++ b/lib/alignment_1.sh
@@ -157,7 +157,7 @@ function alignment::segemehl(){
 				ln -sfnr "$o.sngl.bed" "$o.sj"
 			CMD
 		fi
-		segemehl+=("$o.bam")
+		segemehl[$i]="$o.bam"
 	done
 
 	if $skip; then
@@ -388,14 +388,14 @@ function alignment::star(){
 			CMD
 				ln -sfnr "$o.SJ.out.tab" "$o.sj"
 			CMD
-			star+=("$o.transcriptomic.bam")
+			star[$i]="$o.transcriptomic.bam"
 		else
 			commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 				mv "$o.Aligned.out.bam" "$o.bam"
 			CMD
 				ln -sfnr "$o.SJ.out.tab" "$o.sj"
 			CMD
-			star+=("$o.bam")
+			star[$i]="$o.bam"
 		fi
 	done
 
@@ -492,7 +492,7 @@ function alignment::bwa(){
 
 	commander::printinfo "mapping bwa"
 
-	# use absolute path, because on some maschines sometimes bwa-mem2 aborts with error: prefix is too long
+	# use absolute path, because on some machines sometimes bwa-mem2 aborts with error: prefix is too long
 	declare -a cmdchk=("which bwa-mem2 &> /dev/null && which bwa-mem2 || echo bwa")
 	local bwacmd=$(commander::runcmd -c bwa -a cmdchk)
 
@@ -622,7 +622,7 @@ function alignment::bwa(){
 				CMD
 			fi
 		fi
-		bwa+=("$o1.bam")
+		bwa[$i]="$o1.bam"
 	done
 
 	if $skip; then
@@ -2070,6 +2070,7 @@ function alignment::qcstats(){
 				-p "${tdirs[-1]}" \
 				-h "$(echo -e "$header")" \
 				-o "$odir/insertsizes.histogram.tsv" \
+				-d \
 				"${tojoin[@]}"
 
 			commander::makecmd -a cmd2 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD

--- a/lib/alignment_1.sh
+++ b/lib/alignment_1.sh
@@ -1052,7 +1052,8 @@ function alignment::_blacklist(){
 					-@ $threads
 					-b
 					-L "$tmpdir/whitelist.bed"
-					-o "$_returnfile_blacklist"
+					--write-index
+					-o "$_returnfile_blacklist##idx##${_returnfile_blacklist%.*}.bai"
 					"$bam"
 			CMD
 		fi
@@ -1063,7 +1064,8 @@ function alignment::_blacklist(){
 				-@ $threads
 				-b
 				-e 'rname!="$blacklist"'
-				-o "$_returnfile_blacklist"
+				--write-index
+				-o "$_returnfile_blacklist##idx##${_returnfile_blacklist%.*}.bai"
 				"$bam"
 		CMD
 	fi

--- a/lib/alignment_2.sh
+++ b/lib/alignment_2.sh
@@ -264,7 +264,7 @@ function alignment::rmduplicates(){
 					CMD
 						| awk -v f=<(helper::cat -f "${umi_rmduplicates[$i]}" | paste - - - -)
 					CMD
-						-v OFS='\t' '/^@\S\S\s/{print; next}{l=$0; r="@"$1; getline < f; while(r!=$1){getline < f} print l,"RX:Z:"$(NF-2)}'
+						-v OFS='\t' '/^@\S\S\s/{print; next}{l=$0; r="@"$1; getline < f; while(r!=$1){getline < f} print l,"RX:Z:"$(NF-2),"QX:Z:"$NF}'
 					CMD
 						| samtools sort
 							-@ $ithreads

--- a/lib/bigwig.sh
+++ b/lib/bigwig.sh
@@ -64,7 +64,7 @@ function bigwig::_apply(){
 				-t $threads \
 				-p ${tdirs[-1]} \
 				-f tomerge \
-				-o "$odir/$c.mean.pileup.tpm.bw" \
+				-o "$odir/$c.$job.pileup.tpm.bw" \
 				-j $job \
 				-e $missing
 		done
@@ -220,7 +220,7 @@ function bigwig::profiles(){
 	done
 	[[ $# -eq 0 ]] && { _usage || return 0; }
 	[[ $mandatory -lt 4 ]] && _usage
-	[[ ! $_bedfiles_profiles && ! $gtf ]] && _usage
+	# [[ ! $_bedfiles_profiles && ! $gtf ]] && _usage
 
 	$pearson && commander::printinfo "correlating bigwigs and creating profiles" || commander::printinfo "creating bigwig profiles"
 
@@ -245,7 +245,7 @@ function bigwig::profiles(){
 
 		for f in "${_bams_profiles[@]}"; do
 			$pearson && coverages+=("$(find -L "$bwdir/$m" -maxdepth 1 -name "$(basename ${f%.*}).coverage.tpm.bw" -print -quit | grep .)")
-			pileups+=("$(find -L "$bwdir/$m" -maxdepth 1 -name "$(basename ${f%.*}).pileup.tpm.bw" -print -quit | grep .)")
+			[[ $toprofile || $gtf ]] && pileups+=("$(find -L "$bwdir/$m" -maxdepth 1 -name "$(basename ${f%.*}).pileup.tpm.bw" -print -quit | grep .)")
 		done
 
 		[[ ${#pileups[@]} -gt 1 ]] && e="$(echo -e "${pileups[0]}\t${pileups[1]}" | sed -E 's/(.+)\t.*\1/\t\1/' | cut -f 2)" || e=".pileup.tpm.bw"

--- a/lib/bisulfite.sh
+++ b/lib/bisulfite.sh
@@ -815,6 +815,7 @@ function bisulfite::mecall(){
 					next unless $F[-1]=~/^$c/ && $F[2]=~/$s/;
 					next if $F[3]+$F[4]==0;
 					$F[1]=$F[1]-(length($F[5])-1) if $F[2] eq "-";
+					$F[1]=1 if $F[1]<1;
 					print join"\t",($F[0],$F[1]-1,$F[1],$F[3],$F[3]+$F[4]);
 				'
 			CMD
@@ -929,6 +930,7 @@ function bisulfite::methyldackel(){
 					next unless $F[-1]=~/^$c/ && $F[2]=~/$s/;
 					next if $F[3]+$F[4]==0;
 					$F[1]=$F[1]-(length($F[5])-1) if $F[2] eq "-";
+					$F[1]=1 if $F[1]<1;
 					print join"\t",($F[0],$F[1]-1,$F[1],$F[3],$F[3]+$F[4]);
 				'
 			CMD

--- a/lib/cluster.sh
+++ b/lib/cluster.sh
@@ -137,7 +137,7 @@ function cluster::coexpression_deseq(){
 							$m{$1}=1;
 						}
 					}
-				' -- -cb="$biotype" -ft="$feature" "$({ readlink -e "$gtf.info" "$gtf" || true; } | head -1 | grep .)" > "$tmp.genes"
+				' -- -cb="$biotype" -ft="$feature" "$({ realpath -se "$gtf.info" "$gtf" 2> /dev/null || true; } | head -1 | grep .)" > "$tmp.genes"
 				grep -Fw -f "$tmp.genes" "$odir/experiments.filtered.genes" > "$tmp.filtered.genes"
 				mv "$tmp.filtered.genes" "$odir/experiments.filtered.genes"
 			}
@@ -414,7 +414,7 @@ function cluster::coexpression(){
 						$m{$1}=1;
 					}
 				}
-			' -- -cb="$biotype" -ft="$feature" "$({ readlink -e "$gtf.info" "$gtf" || true; } | head -1 | grep .)" > "$tmp.genes"
+			' -- -cb="$biotype" -ft="$feature" "$({ realpath -se "$gtf.info" "$gtf" 2> /dev/null || true; } | head -1 | grep .)" > "$tmp.genes"
 			grep -Fw -f "$tmp.genes" "$odir/experiments.filtered.genes" > "$tmp.filtered.genes"
 			mv "$tmp.filtered.genes" "$odir/experiments.filtered.genes"
 		}

--- a/lib/compile.sh
+++ b/lib/compile.sh
@@ -1031,7 +1031,8 @@ function compile::m6aviewer(){
 	if [[ -e "$src" ]] && $cfg; then
 		url=$(cat "$src")
 	else
-		url='http://dna2.leeds.ac.uk/m6a/m6aViewer_1_6_1.jar'
+		# url='http://dna2.leeds.ac.uk/m6a/m6aViewer_1_6_1.jar'
+		url='https://gitlab.leibniz-fli.de/kriege/m6aviewer/-/raw/main/m6aviewer.jar'
 	fi
 	mkdir -p "$insdir/config"
 	echo "$url" > "$insdir/config/m6aviewer.url"

--- a/lib/compile.sh
+++ b/lib/compile.sh
@@ -582,11 +582,13 @@ function compile::conda_tools(){
 			mamba install -n $n -y --override-channels -c conda-forge -c bioconda -c defaults $tool bwa-mem2
 		fi
 		# get latest functions from pull requensts like support for bwa-mem2 and report of supplementary/split alignments
+		# use absolute path, because on some machines sometimes bwa-mem2 aborts with error: prefix is too long
 		curl -s "https://raw.githubusercontent.com/brentp/bwa-meth/master/bwameth.py" | \
 			sed -E -e '/--threads/{s/$/\n    p.add_argument("-s", "--score", type=int, default=40)/}' \
 			-e '/threads=args.threads/{s/$/\n            score=args.score,/}' \
 			-e 's/threads=1,/threads=1, score=40,/' \
-			-e 's/"\|bwa(.+) -T 40 -B 2 -L 10 -CM/f"|bwa\1 -T {score} -a -B 2 -L 10 -C -Y/' \
+			-e 's@"bwa-mem2 index@"\\\"" + os.path.dirname(__file__) + "/bwa-mem2\\\" index@' \
+			-e 's@bwa-mem2 mem -T 40 -B 2 -L 10 -CM@ \\\"" + os.path.dirname(__file__) + f"/bwa-mem2\\\" mem -T {score} -a -B 2 -L 10 -C -Y@' \
 		> "$insdir/conda/envs/bwameth/bin/bwameth.py"
 		# by removal of -M splits/chimeric reads are marked as supplementary (which is the way to go!).
 		# -Y: apply soft-clipping instead of hard clipping to keep sequence info in bam (can be changed via)

--- a/lib/enrichment.sh
+++ b/lib/enrichment.sh
@@ -685,7 +685,7 @@ function enrichment::go(){
 					$m{$1}=1;
 				}
 			}
-		' -- -cb="$biotype" -ft="$feature" "$({ readlink -e "$gtf.info" "$gtf" || true; } | head -1 | grep .)" > "$whitelist"
+		' -- -cb="$biotype" -ft="$feature" "$({ realpath -se "$gtf.info" "$gtf" 2> /dev/null || true; } | head -1 | grep .)" > "$whitelist"
 	}
 
 	for f in "${_idfiles_go[@]}"; do

--- a/lib/helper.sh
+++ b/lib/helper.sh
@@ -1002,7 +1002,7 @@ function helper::multijoin(){
 function helper::ishash(){
 	function _usage(){
 		commander::print <<- 'EOF'
-			helper::ishash returns without error if given variable is an associative array i.e. hash
+			helper::ishash returns without error if given variable or refers to an associative array i.e. hash
 
 			-v <var> | variable
 		EOF
@@ -1012,10 +1012,8 @@ function helper::ishash(){
 	local OPTIND arg
 	while getopts 'v:' arg; do
 		case $arg in
-			v)	{	declare -p "$OPTARG" &> /dev/null
-					declare -n __="$OPTARG"
-					[[ "$(declare -p ${!__})" =~ ^declare\ \-[Ab-z]+ ]]
-				} || return 1
+			v)	declare -n __="$OPTARG"
+				[[ ${!__@a} == *A* ]] || return 1
 			;;
 			*)	_usage;;
 		esac
@@ -1028,21 +1026,18 @@ function helper::ishash(){
 function helper::isarray(){
 	function _usage(){
 		commander::print <<- 'EOF'
-			helper::isarray returns without error if given variable is an array
+			helper::isarray returns without error if given variable is or refers to an array
 
 			-v <var> | variable
 		EOF
 		return 1
 	}
 
-	local OPTIND arg mandatory var
-	declare -a vars
+	local OPTIND arg
 	while getopts 'v:' arg; do
 		case $arg in
-			v)	{	declare -p "$OPTARG" &> /dev/null
-					declare -n __="$OPTARG"
-					[[ "$(declare -p ${!__})" =~ ^declare\ \-[a-zB-Z]+ ]]
-				} || return 1
+			v)	declare -n __="$OPTARG"
+				[[ ${!__@a} == *a* ]] || return 1
 			;;
 			*)	_usage;;
 		esac

--- a/lib/helper.sh
+++ b/lib/helper.sh
@@ -712,7 +712,8 @@ function helper::multijoin(){
 			-h <header>    | optional. header string to be reported
 			-e <empty>     | optional. string for empty/null fields. default: NA
 			-o <outfile>   | optional. path to output table. default: stdout
-			-b             | optional. data is sorted bed or bedgraph format i.e. ignores -s -n
+			-b <seqidsfile>| optional. data is positional sorted bed/bedgraph format with sequence identifiers ordered according to first column of given file
+			-d             | optional. all columns to be used as id group contain numerically, increasingly sorted digits
 
 			example
 			helper::multijoin <path> <path> [<path> ..]
@@ -735,9 +736,9 @@ function helper::multijoin(){
 		return 1
 	}
 
-	local OPTIND arg mandatory outfile=/dev/stdout header empty=NA sep=$'\t' tmpdir group=1 range=1- bed=false execute=true threads=1
+	local OPTIND arg mandatory outfile=/dev/stdout header empty=NA sep=$'\t' tmpdir group=1 range=1- bed=false execute=true threads=1 digits=false seqids
 	declare -n _cmds_multijoin _files_multijoin
-	while getopts '1:t:s:h:e:o:n:r:p:f:b' arg; do
+	while getopts '1:t:s:h:e:o:n:r:p:f:b:d' arg; do
 		case $arg in
 			1)	execute=false; _cmds_multijoin=$OPTARG;;
 			t)	threads="$OPTARG";;
@@ -749,7 +750,8 @@ function helper::multijoin(){
 			o)	outfile="$OPTARG"; mkdir -p "$(dirname "$outfile")";;
 			p)	tmpdir="$OPTARG";;
 			f)	_files_multijoin="$OPTARG";;
-			b)	bed=true;;
+			b)	seqids="$OPTARG"; bed=true;;
+			d)	digits=true;;
 			*) _usage;;
 		esac
 	done
@@ -793,18 +795,84 @@ function helper::multijoin(){
 						o="$outfile"
 						# padding positions by leading zeroes
 						# and use padded rank instead of fasta seq ids.
-						commander::makecmd -s ' ' -a __cmds_multijoin -c {COMMANDER[0]}<<-CMD {COMMANDER[1]}<<-CMD {COMMANDER[2]}<<-CMD {COMMANDER[3]}<<-'CMD' {COMMANDER[4]}<<-CMD {COMMANDER[5]}<<-'CMD' {COMMANDER[6]}<<-CMD {COMMANDER[7]}<<-CMD
+						commander::makecmd -s ' ' -a __cmds_multijoin -c {COMMANDER[0]}<<-CMD {COMMANDER[1]}<<-CMD {COMMANDER[2]}<<-'CMD' {COMMANDER[3]}<<-CMD {COMMANDER[4]}<<-'CMD' {COMMANDER[5]}<<-CMD {COMMANDER[6]}<<-CMD {COMMANDER[7]}<<-CMD
 							$([[ $header ]] && echo "echo -e '$header' > '$o';" || rm -f "$o" &> /dev/null || true)
 						CMD
 							join -o 0\$({ head -1 "$f1"; head -1 "$f2"; } | awk -F '\t' '{for(i=2;i<=NF-2;i++){printf ",%s",NR"."i}}') -1 1 -2 1 -a 1 -a 2 -e "$empty" -t \$'\t'
 						CMD
-							<(cat "$f1"
+							<(awk -F '\t' -v OFS='\t' '{f+=FNR==1?1:0} f==1{h[$1]=NR} f==2{$3=sprintf("%010d",h[$1])sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}'
 						CMD
-								| awk -F '\t' -v OFS='\t' '{r += h[$1] ? 0 : 1; h[$1]=1; $3=sprintf("%010d",r)sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}' | cut -f 3-)
+								"$seqids" "$f1" | cut -f 3-)
 						CMD
-							<(cat "$f2"
+							<(awk -F '\t' -v OFS='\t' '{f+=FNR==1?1:0} f==1{h[$1]=NR} f==2{$3=sprintf("%010d",h[$1])sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}'
 						CMD
-								| awk -F '\t' -v OFS='\t' '{r += h[$1] ? 0 : 1; h[$1]=1; $3=sprintf("%010d",r)sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}' | cut -f 3-)
+								"$seqids" "$f2" | cut -f 3-)
+						CMD
+							| sed 's/#:::#/\t/g' | cut -f 2- | cut -f $range >> "$o";
+						CMD
+							$([[ "$f1" == *"$tmpdir/tojoin"* ]] && echo "rm '$f1';"; [[ "$f2" == *"$tmpdir/tojoin"* ]] && echo "rm '$f2'")
+						CMD
+					else
+						((++j))
+						o="$tmpdir/tojoin.$r.$j"
+						commander::makecmd -s ' ' -a __cmds_multijoin -c {COMMANDER[0]}<<-CMD {COMMANDER[1]}<<-'CMD' {COMMANDER[2]}<<-CMD {COMMANDER[3]}<<-'CMD' {COMMANDER[4]}<<-CMD {COMMANDER[5]}<<-CMD {COMMANDER[6]}<<-CMD
+							join -o 0\$({ head -1 "$f1"; head -1 "$f2"; } | awk -F '\t' '{for(i=2;i<=NF-2;i++){printf ",%s",NR"."i}}') -1 1 -2 1 -a 1 -a 2 -e "$empty" -t \$'\t'
+						CMD
+							<(awk -F '\t' -v OFS='\t' '{f+=FNR==1?1:0} f==1{h[$1]=NR} f==2{$3=sprintf("%010d",h[$1])sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}'
+						CMD
+								"$seqids" "$f1" | cut -f 3-)
+						CMD
+							<(awk -F '\t' -v OFS='\t' '{f+=FNR==1?1:0} f==1{h[$1]=NR} f==2{$3=sprintf("%010d",h[$1])sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}'
+						CMD
+								"$seqids" "$f2" | cut -f 3-)
+						CMD
+							| sed 's/#:::#/\t/g' | cut -f 2- > "$o";
+						CMD
+							$([[ "$f1" == *"$tmpdir/tojoin"* ]] && echo "rm '$f1';"; [[ "$f2" == *"$tmpdir/tojoin"* ]] && echo "rm '$f2'";)
+						CMD
+						joined+=("$o")
+					fi
+				else
+					joined+=("${tojoin[$i]}")
+				fi
+			done
+			tojoin=("${joined[@]}")
+			((++r))
+		done
+	elif $digits; then
+		local zeroes=$(tail -q -n 1 "${tojoin[@]}" | cut -f 1-$group | tr "$sep" '\n' | awk '{x=length($0);m=m>x?m:x}END{print m}')
+		while [[ ${#tojoin[@]} -gt 1 ]]; do
+			joined=()
+			j=0
+			if [[ ${_cmds_multijoin[$r]} ]]; then
+				declare -n __cmds_multijoin=${_cmds_multijoin[$r]}
+			else
+				declare -g -a multijoincmd$r
+				declare -n __cmds_multijoin=multijoincmd$r
+				__cmds_multijoin=()
+				_cmds_multijoin[$r]=multijoincmd$r
+			fi
+
+			for i in $(seq 0 2 $((${#tojoin[@]}-1))); do
+				if [[ ${tojoin[$((i+1))]} ]]; then
+					f1="${tojoin[$i]}"
+					f2="${tojoin[$((i+1))]}"
+					if [[ ${#tojoin[@]} -eq 2 ]]; then
+						o="$outfile"
+						# padding positions by leading zeroes
+						# and use padded rank instead of fasta seq ids.
+						commander::makecmd -s ' ' -a __cmds_multijoin -c {COMMANDER[0]}<<-CMD {COMMANDER[1]}<<-CMD {COMMANDER[2]}<<-CMD {COMMANDER[3]}<<-'CMD' {COMMANDER[4]}<<-CMD {COMMANDER[5]}<<-'CMD' {COMMANDER[6]}<<-CMD {COMMANDER[7]}<<-CMD
+							$([[ $header ]] && echo "echo -e '$header' > '$o';" || rm -f "$o" &> /dev/null || true)
+						CMD
+							join -o 0\$({ head -1 "$f1"; head -1 "$f2"; } | awk -F "$sep" -v r=$group '{for(i=2;i<=NF-r+1;i++){printf ",%s",NR"."i}}') -1 1 -2 1 -a 1 -a 2 -e "$empty" -t \$'\t'
+						CMD
+							<(cat "$f1" | awk -F '\t' -v OFS='\t' -v r=$group -v n=$zeroes
+						CMD
+								'{x=$r; $r=sprintf("%010d",$r); for(i=1;i<r;i++){x=$i"#:::#"x; $r=sprintf("%0"n"d",$i)$r; $i=""} $r=$r"#:::#"x; print}' | sed 's/^\s*//')
+						CMD
+							<(cat "$f2" | awk -F '\t' -v OFS='\t' -v r=$group -v n=$zeroes
+						CMD
+								'{x=$r; $r=sprintf("%010d",$r); for(i=1;i<r;i++){x=$i"#:::#"x; $r=sprintf("%0"n"d",$i)$r; $i=""} $r=$r"#:::#"x; print}' | sed 's/^\s*//')
 						CMD
 							| sed 's/#:::#/\t/g' | cut -f 2- | cut -f $range >> "$o";
 						CMD
@@ -814,15 +882,15 @@ function helper::multijoin(){
 						((++j))
 						o="$tmpdir/tojoin.$r.$j"
 						commander::makecmd -s ' ' -a __cmds_multijoin -c {COMMANDER[0]}<<-CMD {COMMANDER[1]}<<-CMD {COMMANDER[2]}<<-'CMD' {COMMANDER[3]}<<-CMD {COMMANDER[4]}<<-'CMD' {COMMANDER[5]}<<-CMD {COMMANDER[6]}<<-CMD
-							join -o 0\$({ head -1 "$f1"; head -1 "$f2"; } | awk -F '\t' '{for(i=2;i<=NF-2;i++){printf ",%s",NR"."i}}') -1 1 -2 1 -a 1 -a 2 -e "$empty" -t \$'\t'
+							join -o 0\$({ head -1 "$f1"; head -1 "$f2"; } | awk -F "$sep" -v r=$group '{for(i=2;i<=NF-r+1;i++){printf ",%s",NR"."i}}') -1 1 -2 1 -a 1 -a 2 -e "$empty" -t \$'\t'
 						CMD
-							<(cat "$f1"
+							<(cat "$f1" | awk -F '\t' -v OFS='\t' -v r=$group -v n=$zeroes
 						CMD
-								| awk -F '\t' -v OFS='\t' '{r += h[$1] ? 0 : 1; h[$1]=1; $3=sprintf("%010d",r)sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}' | cut -f 3-)
+								'{x=$r; $r=sprintf("%010d",$r); for(i=1;i<r;i++){x=$i"#:::#"x; $r=sprintf("%0"n"d",$i)$r; $i=""} $r=$r"#:::#"x; print}' | sed 's/^\s*//')
 						CMD
-							<(cat "$f2"
+							<(cat "$f2" | awk -F '\t' -v OFS='\t' -v r=$group -v n=$zeroes
 						CMD
-								| awk -F '\t' -v OFS='\t' '{r += h[$1] ? 0 : 1; h[$1]=1; $3=sprintf("%010d",r)sprintf("%010d",$2)sprintf("%010d",$3)"#:::#"$1"#:::#"$2"#:::#"$3; print}' | cut -f 3-)
+								'{x=$r; $r=sprintf("%010d",$r); for(i=1;i<r;i++){x=$i"#:::#"x; $r=sprintf("%0"n"d",$i)$r; $i=""} $r=$r"#:::#"x; print}' | sed 's/^\s*//')
 						CMD
 							| sed 's/#:::#/\t/g' | cut -f 2- > "$o";
 						CMD

--- a/lib/peaks_1.sh
+++ b/lib/peaks_1.sh
@@ -39,7 +39,7 @@ function peaks::_bed2narrowpeak(){
 	CMD
 		"$b" | sort -k1,1 -k2,2n -k3,3n > "$tmpdir/peaks";
 	CMD
-		if [[ \$(head -1 "$tmpdir/peaks" | cut -f 10) -eq -1 ]]; then
+		if [[ \$(head -1 "$tmpdir/peaks" | cut -f 10) == -1 ]]; then
 			paste "$tmpdir/peaks" <(macs2 refinepeak
 				-b "$tmpdir/peaks"
 				-i "$i"
@@ -84,7 +84,7 @@ function peaks::_bed2narrowpeak(){
 	CMD
 		> "$tmpdir/summits";
 	CMD
-		if [[ \$(head -1 "$tmpdir/summits" | cut -f 10) -eq -1 ]]; then
+		if [[ \$(head -1 "$tmpdir/summits" | cut -f 10) == -1 ]]; then
 			paste
 				<(bedtools intersect -loj -a "$tmpdir/summits" -b "$(dirname "$i")/model_fc.bedg" | awk -v OFS='\t' '{\$10=\$NF; print}' | cut -f 4-13)
 				<(bedtools intersect -loj -a "$tmpdir/summits" -b "$(dirname "$i")/nomodel_fc.bedg" | awk -v OFS='\t' '{\$10=\$NF; print}' | cut -f 4-13);
@@ -1791,7 +1791,7 @@ function peaks::genrich(){
 	if $broad; then
 		params+=" -l 150 -g 400"
 	else
-		$ripseq && pointy && params=" -l 100 -g 50" || params=" -l 100 -g 100"
+		$ripseq && $pointy && params+=" -l 100 -g 50" || params+=" -l 100 -g 100"
 	fi
 	$strict && params+=' -p 0.01' || params+=' -p 0.05'
 

--- a/lib/preprocess.sh
+++ b/lib/preprocess.sh
@@ -171,7 +171,7 @@ function preprocess::fastqc(){
 
 		helper::basename -f "$f" -o b -e e
 		e=$(echo $e | cut -d '.' -f 1) # if e == fastq or fq : check for ${b}_fastqc.zip else $b.${e}_fastqc.zip
-		[[ $e == "fastq" || $e == "fq" ]] && f="${b}_fastqc.zip" || f="$b.${e}_fastqc.zip"
+		[[ "$e" == "fastq" || "$e" == "fq" ]] && f="${b}_fastqc.zip" || f="$b.${e}_fastqc.zip"
 		# attention: nugen adapter search causes low false positive rates in R2 seqeunces (<0.1) likewise Small RNA adapter in R1 (<0.01)
 		commander::makecmd -a cmd2 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- 'CMD' {COMMANDER[2]}<<- CMD
 			unzip -c "$outdir/$f" "${f%.*}/fastqc_data.txt" | tac
@@ -201,7 +201,7 @@ function preprocess::fastqc(){
 				exit
 			}'
 		CMD
-			tee "$($skip && echo "/dev/null" || echo "$outdir/$b.adapter")"
+			tee "$($skip && echo "/dev/null" || echo "${f%_fastqc.zip}.adapter")"
 		CMD
 	done
 
@@ -236,6 +236,11 @@ function preprocess::fastqc(){
 
 					helper::basename -f "$f1" -o b1 -e e1
 					helper::basename -f "$f2" -o b2 -e e2
+
+					if [[ "$b1" == "$b2" ]]; then
+						b1+="$e1"
+						b2+="$e2"
+					fi
 
 					tomerge1+=("$outdir/$b1.adapter")
 					tomerge2+=("$outdir/$b2.adapter")

--- a/lib/preprocess.sh
+++ b/lib/preprocess.sh
@@ -201,7 +201,7 @@ function preprocess::fastqc(){
 				exit
 			}'
 		CMD
-			tee "$($skip && echo "/dev/null" || echo "${f%_fastqc.zip}.adapter")"
+			tee "$($skip && echo "/dev/null" || echo "$outdir/${f%_fastqc.zip}.adapter")"
 		CMD
 	done
 

--- a/lib/preprocess.sh
+++ b/lib/preprocess.sh
@@ -475,7 +475,7 @@ function preprocess::trimmomatic(){
 	commander::printinfo "trimming"
 
 	#offset 64: ASCII 64 to 106 (solexa: 59 to 106)
-	#offset 33: ASCII 33 to 75
+	#offset 33: ASCII 33 to 88
 	#64 to 33: ord(char)-33+2
 	#theoretical max range is 126 for all encodings, thus more reliable detection would be just min based
 	#https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2847217/
@@ -499,11 +499,11 @@ function preprocess::trimmomatic(){
 					$max=max($max,@x);
 				}
 				END{
-					if($min>=33 && $max<=75){
+					if($min>=33 && $max<=88){
 						print "phred33 $f";
-					}elsif($min>=64 && $max>75 && $max<=106){
+					}elsif($min>=64 && $max>88 && $max<=106){
 						print "phred64 $f";
-					}elsif($min>=59 && $min<64 && $max>75 && $max<=106){
+					}elsif($min>=59 && $min<64 && $max>88 && $max<=106){
 						print "solexa64 $f";
 					}else{
 						print "unknown $f";

--- a/lib/quantify.sh
+++ b/lib/quantify.sh
@@ -367,7 +367,7 @@ function quantify::featurecounts(){
 			s)	$OPTARG && skip=true;;
 			t)	((++mandatory)); threads=$OPTARG;;
 			r)	((++mandatory)); _mapper_featurecounts=$OPTARG;;
-			x)	((++mandatory)); _strandness_featurecounts=$OPTARG;;
+			x)	((++mandatory)); if [[ $OPTARG == [012] ]]; then unset _strandness_featurecounts; _strandness_featurecounts=$OPTARG; else _strandness_featurecounts=$OPTARG; fi;;
 			g)	((++mandatory)); gtf="$OPTARG";;
 			l)	level=$OPTARG;;
 			M)	maxmemory=$OPTARG;;
@@ -416,7 +416,7 @@ function quantify::featurecounts(){
 						-Q 0
 						--minOverlap 10
 						--maxMOp 999
-						-s ${_strandness_featurecounts["$f"]}
+						-s $([[ $_strandness_featurecounts ]] && echo $_strandness_featurecounts || echo ${_strandness_featurecounts["$f"]})
 						-T $ithreads
 						-t $level
 						-g transcript_id
@@ -462,7 +462,7 @@ function quantify::featurecounts(){
 						-Q 0
 						--minOverlap 10
 						--maxMOp 999
-						-s ${_strandness_featurecounts["$f"]}
+						-s $([[ $_strandness_featurecounts ]] && echo $_strandness_featurecounts || echo ${_strandness_featurecounts["$f"]})
 						-T $ithreads
 						-t $level
 						-g ${feature}_id

--- a/lib/variants_2.sh
+++ b/lib/variants_2.sh
@@ -20,7 +20,7 @@ function variants::haplotypecaller(){
 		return 1
 	}
 
-	local OPTIND arg mandatory skip=false threads memory maxmemory genome dbsnp dbsnpfilter=true tmpdir="${TMPDIR:-/tmp}" outdir isdna=true
+	local OPTIND arg mandatory skip=false threads memory maxmemory genome dbsnp tmpdir="${TMPDIR:-/tmp}" outdir isdna=true
 	declare -n _mapper_haplotypecaller _bamslices_haplotypecaller
 	while getopts 'S:s:t:g:d:e:m:M:r:c:o:' arg; do
 		case $arg in
@@ -41,24 +41,16 @@ function variants::haplotypecaller(){
 	[[ $# -eq 0 ]] && { _usage || return 0; }
 	[[ $mandatory -lt 6 ]] && _usage
 
-	if [[ ! $dbsnp ]]; then
-		dbsnpfilter=false
-
-		local tmpfile="$(mktemp -p "$tmpdir" cleanup.XXXXXXXXXX.vcf.gz)"
-		dbsnp="$tmpfile"
-		echo -e "##fileformat=VCFv4.0\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO" | bgzip -k -c -@ $threads > "$tmpfile"
-		tabix -f -p vcf "$tmpfile"
-		dbsnp="$tmpfile"
-	fi
-
 	commander::printinfo "calling variants haplotypecaller"
 
 	local minstances mthreads jmem jgct jcgct
 	read -r minstances mthreads jmem jgct jcgct < <(configure::jvm -T $threads -m $memory -M "$maxmemory")
-	eclare -n _bams_haplotypecaller="${_mapper_haplotypecaller[0]}"
-	local i memory ithreads instances=$((${#_mapper_haplotypecaller[@]}*${#_bams_haplotypecaller[@]}))
-	read -r i memory < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -T $threads)
+	declare -n _bams_haplotypecaller="${_mapper_haplotypecaller[0]}"
+	local ignore instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_haplotypecaller[@]}*${#_bams_haplotypecaller[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*minstances*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
 
 	local m i o t e slice odir tdir
 	declare -a tdirs tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6
@@ -69,6 +61,9 @@ function variants::haplotypecaller(){
 		mkdir -p "$odir" "$tdir"
 
 		for i in "${!_bams_haplotypecaller[@]}"; do
+			o="$(basename "${_bams_haplotypecaller[$i]}")"
+			t="$tdir/${o%.*}"
+			o="$odir/${o%.*}"
 			tomerge=()
 
 			while read -r slice; do
@@ -96,7 +91,6 @@ function variants::haplotypecaller(){
 						-I "$slice"
 						-O "$slice.unfiltered.vcf"
 						-R "$genome"
-						-D "$dbsnp"
 						-A Coverage
 						-A DepthPerAlleleBySample
 						-A StrandBiasBySample
@@ -112,6 +106,9 @@ function variants::haplotypecaller(){
 						-verbosity INFO
 						--tmp-dir "${tdirs[-1]}"
 				CMD
+				# in HC < v4 dbSNP input was required
+				# -D "$dbsnp" # does annotation only - i.e. transferring varaint id (RS ID) from dbSNP to vcf only
+				# adds ##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
 
 				if $isdna; then
 					# or 'QD<2.0||MQ<40.0||FS>60.0||MQRankSum<−12.5||ReadPosRankSum<−8.0'
@@ -144,6 +141,7 @@ function variants::haplotypecaller(){
 							--tmp-dir "${tdirs[-1]}"
 					CMD
 				else
+					# https://github.com/gatk-workflows/gatk4-rnaseq-germline-snps-indels/blob/master/gatk4-rna-best-practices.wdl
 					commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD
 						MALLOC_ARENA_MAX=4 gatk
 							--java-options '
@@ -177,7 +175,7 @@ function variants::haplotypecaller(){
 					vcfix.pl -i - > "$slice.fixed.nomulti.vcf"
 				CMD
 
-				if $dbsnpfilter; then
+				if [[ $dbsnp ]]; then
 					commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
 						vcffixup "$slice.fixed.nomulti.vcf"
 					CMD
@@ -199,27 +197,28 @@ function variants::haplotypecaller(){
 					CMD
 				fi
 
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+					commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
 				tomerge+=("$slice")
 			done < "${_bamslices_haplotypecaller[${_bams_haplotypecaller[$i]}]}"
 
-			o="$(basename "${_bams_haplotypecaller[$i]}")"
-			t="$tdir/${o%.*}"
-			o="$odir/${o%.*}"
-
-			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $($dbsnpfilter && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
+			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$t.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.$e" "$t.$e"
-				CMD
-
-				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 > "$o.$e.gz"
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
+				# sorting required to retain chromosomal order
 			done
 		done
 	done
@@ -238,8 +237,8 @@ function variants::haplotypecaller(){
 		commander::runcmd -v -b -i $threads -a cmd3
 		commander::runcmd -v -b -i $threads -a cmd4
 		commander::runcmd -v -b -i $threads -a cmd5
-		commander::runcmd -v -b -i $threads -a cmd6
-		commander::runcmd -v -b -i $instances -a cmd7
+		commander::runcmd -v -b -i $instances1 -a cmd6
+		commander::runcmd -v -b -i $instances2 -a cmd7
 	fi
 
 	return 0
@@ -251,15 +250,10 @@ function variants::mutect(){
 	# Instead you may use gs://gatk-best-practices/somatic-b37/Mutect2-exome-panel.vcf.
 	# For the -germline-resource you should use gs://gatk-best-practices/somatic-b37/af-only-gnomad.raw.sites.vcf.
 	# -> this seems to be replacing old dbSNP input, which does not have AF info field
-	# For the -V and -L arguments to GetPileupSummaries you may use gs://gatk-best-practices/somatic-b37/small_exac_common_3.vcf.
-	# -> can this be used? ftp://ftp.ncbi.nih.gov/snp/organisms/human_9606_b151_GRCh38p7/VCF/GATK/00-common_all.vcf.gz
-	# -> cam this be used? ftp://ftp.ensembl.org/pub/current_variation/vcf/homo_sapiens/homo_sapiens_somatic.vcf.gz
-	# BUT b37 => HG19 ...
-	# https://software.broadinstitute.org/gatk/download/bundle
-	# https://console.cloud.google.com/storage/browser/gatk-best-practices/somatic-hg38/
-	# BUT this is b37 (similar to hg19) liftovered data (picard LiftoverVCF ? ENSEMBL/NCBI remap?)
-	# from helsinki workshop to create gatk tutotial webpage : https://software.broadinstitute.org/gatk/documentation/article?id=11136
-	# data downloaded to /misc/paras/data/genomes/GRCh38.p12/GATK-resources
+	# For the -V and -L arguments to GetPileupSummaries you may use gs://gatk-best-practices/somatic-b37/small_exac_common_3.vcf
+	# see also https://gatk.broadinstitute.org/hc/en-us/articles/360035890811-Resource-bundle
+	# hg38 data mainly comes from helsinki workshop to create hg19 liftover and gatk tutotial
+	# -> https://software.broadinstitute.org/gatk/documentation/article?id=11136
 
 	function _usage(){
 		commander::print {COMMANDER[0]}<<- EOF
@@ -274,7 +268,8 @@ function variants::mutect(){
 			-1 <normalidx> | array of (requieres -2)
 			-2 <tumoridx>  | array of
 			-c <sliceinfo> | array of
-			-d <pondb>     | path to
+			-n <pondb>     | path to
+			-d <dbsnp>     | path to
 			-o <outdir>    | path to
 		EOF
 		return 1
@@ -305,16 +300,19 @@ function variants::mutect(){
 
 	commander::printinfo "calling variants mutect"
 
-	local minstances mthreads jmem jgct jcgct minstances2 mthreads2 jmem2 jgct2 jcgct2
+	local minstances mthreads jmem jgct jcgct
 	read -r minstances mthreads jmem jgct jcgct < <(configure::jvm -T $threads -m $memory -M "$maxmemory")
-	local params params2 m i o t nslice slice odir tdir ithreads instances=$((${#_mapper_mutect[@]}*${#_tidx_mutect[@]}))
-	read -r i memory < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -T $threads)
-	read -r minstances2 mthreads2 jmem2 jgct2 jcgct2 < <(configure::jvm -i $instances -T $threads -M "$maxmemory")
+	local ignore jmem2 jgct2 jcgct2 instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_mutect[@]}*${#_tidx_mutect[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r ignore ignore jmem2 jgct2 jcgct2 < <(configure::jvm -i $instances -T $threads -M "$maxmemory") # for gatk simple tasks like gathering
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*minstances*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
 
 	[[ $pondb ]] && params="-pon '$pondb'"
-	[[ -s "$genome.af_only_gnomad.vcf.gz" ]] && params+=" --germline-resource '$genome.af_only_gnomad.vcf.gz'"
+	[[ -s "$genome.gnomAD_with_AF.vcf.gz" ]] && params+=" --germline-resource '$genome.gnomAD_with_AF.vcf.gz'"
 
+	local params params2 m i o t nslice slice odir tdir filterdir="$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.filterdata)"
 	declare -a tdirs tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6 cmd7 cmd8 cmd9 cmd10
 	for m in "${_mapper_mutect[@]}"; do
 		declare -n _bams_mutect=$m
@@ -323,10 +321,15 @@ function variants::mutect(){
 		mkdir -p "$odir" "$tdir"
 
 		for i in "${!_tidx_mutect[@]}"; do
+			o="$(basename "${_bams_mutect[${_tidx_mutect[$i]}]}")"
+			t="$tdir/${o%.*}"
+			o="$odir/${o%.*}"
 			tomerge=()
 
 			while read -r nslice slice; do
+				tomerge+=("$slice")
 				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+
 				# normal name defined for RGSM sam header entry by alignment::addreadgroup
 				commander::makecmd -a cmd1 -s ';' -c {COMMANDER[0]}<<- CMD
 					MALLOC_ARENA_MAX=4 gatk
@@ -377,7 +380,27 @@ function variants::mutect(){
 
 				# --dont-use-soft-clipped-bases recommended for RNA based calling due to splitNcigar which elongates both splits towards full length read alignments and mask them\n\t\t\t\t# since we are doing clipmateoverlap, which introduces soft-clips, always enable this option
 
-				if [[ -s "$genome.small_common.vcf.gz" ]]; then
+				if [[ -s "$genome.ExAC_common.vcf.gz" ]]; then
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+					commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD
+						MALLOC_ARENA_MAX=4 gatk
+							--java-options '
+								-Xmx${jmem}m
+								-XX:ParallelGCThreads=$jgct
+								-XX:ConcGCThreads=$jcgct
+								-Djava.io.tmpdir="$tmpdir"
+								-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
+							'
+							GetPileupSummaries
+							-I "$nslice"
+							-V "$genome.ExAC_common.vcf.gz"
+							-L "$genome.ExAC_common.vcf.gz"
+							-O "$slice.normal.pileups.table"
+							--verbosity INFO
+							--tmp-dir "${tdirs[-1]}"
+					CMD
+
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
 					commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD
 						MALLOC_ARENA_MAX=4 gatk
 							--java-options '
@@ -389,53 +412,18 @@ function variants::mutect(){
 							'
 							GetPileupSummaries
 							-I "$slice"
-							-V "$genome.small_common.vcf.gz"
-							-L "$genome.small_common.vcf.gz"
-							-O "$slice.pileups.table"
+							-V "$genome.ExAC_common.vcf.gz"
+							-L "$genome.ExAC_common.vcf.gz"
+							-O "$slice.tumor.pileups.table"
 							--verbosity INFO
 							--tmp-dir "${tdirs[-1]}"
 					CMD
 
-
-					##########
-					#TODO awk 'NR>2' *slice?.bam.pileups.table | sort -k1,1V -k2,2n  BUT -k1,1 must be in order of $genome.list
-					# then predict contamination as whole and filter on full set
-					##########
-					commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
-						MALLOC_ARENA_MAX=4 gatk
-							--java-options '
-								-Xmx${jmem}m
-								-XX:ParallelGCThreads=$jgct
-								-XX:ConcGCThreads=$jcgct
-								-Djava.io.tmpdir="$tmpdir"
-								-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
-							'
-							CalculateContamination
-							-I "$slice.pileups.table"
-							-O "$slice.contamination.table"
-							--tumor-segmentation "$slice.tumorsegments.table"
-							--verbosity INFO
-							--tmp-dir "${tdirs[-1]}"
-					CMD
-					params2=" --contamination-table '$slice.contamination.table' --tumor-segmentation '$slice.tumorsegments.table'"
+					params2="--contamination-table '$filterdir/contamination.table' --tumor-segmentation '$filterdir/tumorsegments.table'"
 				fi
 
-				commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
-					MALLOC_ARENA_MAX=4 gatk
-						--java-options '
-							-Xmx${jmem}m
-							-XX:ParallelGCThreads=$jgct
-							-XX:ConcGCThreads=$jcgct
-							-Djava.io.tmpdir="$tmpdir"
-							-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
-						'
-						LearnReadOrientationModel
-						-I "$slice.f1r2.tar.gz"
-						-O "$slice.f1r2_model.tar.gz"
-						--tmp-dir "${tdirs[-1]}"
-				CMD
-
-				commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD
 					MALLOC_ARENA_MAX=4 gatk
 						--java-options '
 							-Xmx${jmem}m
@@ -446,7 +434,7 @@ function variants::mutect(){
 						'
 						FilterMutectCalls
 						$params2
-						--ob-priors "$slice.f1r2_model.tar.gz"
+						--ob-priors "$filterdir/f1r2_model.tar.gz"
 						-R "$genome"
 						-V "$slice.unfiltered.vcf"
 						-stats "$slice.unfiltered.vcf.stats"
@@ -459,18 +447,18 @@ function variants::mutect(){
 				#In order to tweak results in favor of more sensitivity users may set -f-score-beta to a value greater than its default of 1 (beta is the relative weight of sensitivity versus precision in the harmonic mean). Setting it lower biases results toward greater precision.
 				# optional: --tumor-segmentation segments.table
 
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD
+				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD
 					vcfix.pl -i "$slice.vcf" > "$slice.fixed.vcf"
 				CMD
 
-				commander::makecmd -a cmd7 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+				commander::makecmd -a cmd8 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools norm -f "$genome" -c s -m-both "$slice.fixed.vcf"
 				CMD
 					vcfix.pl -i - > "$slice.fixed.nomulti.vcf"
 				CMD
 
 				if [[ $dbsnp ]]; then
-					commander::makecmd -a cmd8 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
+					commander::makecmd -a cmd9 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
 						vcffixup "$slice.fixed.nomulti.vcf"
 					CMD
 						vt normalize -q -n -r "$genome" -
@@ -482,7 +470,7 @@ function variants::mutect(){
 						vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$slice.fixed.nomulti.normed.nodbsnp.vcf"
 					CMD
 				else
-					commander::makecmd -a cmd8 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					commander::makecmd -a cmd9 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
 						vcffixup "$slice.fixed.nomulti.vcf"
 					CMD
 						vt normalize -q -n -r "$genome" -
@@ -491,15 +479,92 @@ function variants::mutect(){
 					CMD
 				fi
 
-				tomerge+=("$slice")
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+					commander::makecmd -a cmd11 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
+				# tomerge+=("$slice") is on top of loop
 			done < <(paste "${_bamslices_mutect[${_bams_mutect[${_nidx_mutect[$i]}]}]}" "${_bamslices_mutect[${_bams_mutect[${_tidx_mutect[$i]}]}]}")
 
-			o="$(basename "${_bams_mutect[${_tidx_mutect[$i]}]}")"
-			t="$tdir/${o%.*}"
-			o="$odir/${o%.*}"
+			if [[ -s "$genome.ExAC_common.vcf.gz" ]]; then
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
+					MALLOC_ARENA_MAX=4 gatk
+						--java-options '
+							-Xmx${jmem2}m
+							-XX:ParallelGCThreads=$jgct2
+							-XX:ConcGCThreads=$jcgct2
+							-Djava.io.tmpdir="$tmpdir"
+							-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
+						'
+						GatherPileupSummaries
+						--sequence-dictionary "${genome%.*}.dict"
+						$(printf -- '-I "%s" ' "${tomerge[@]/%/.normal.pileups.table}")
+						-O "$filterdir/normal.pileup.table"
+						--tmp-dir "${tdirs[-1]}"
+				CMD
+
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
+					MALLOC_ARENA_MAX=4 gatk
+						--java-options '
+							-Xmx${jmem2}m
+							-XX:ParallelGCThreads=$jgct2
+							-XX:ConcGCThreads=$jcgct2
+							-Djava.io.tmpdir="$tmpdir"
+							-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
+						'
+						GatherPileupSummaries
+						--sequence-dictionary "${genome%.*}.dict"
+						$(printf -- '-I "%s" ' "${tomerge[@]/%/.tumor.pileups.table}")
+						-O "$filterdir/tumor.pileups.table"
+						--tmp-dir "${tdirs[-1]}"
+				CMD
+
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
+					MALLOC_ARENA_MAX=4 gatk
+						--java-options '
+							-Xmx${jmem2}m
+							-XX:ParallelGCThreads=$jgct2
+							-XX:ConcGCThreads=$jcgct2
+							-Djava.io.tmpdir="$tmpdir"
+							-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
+						'
+						CalculateContamination
+						-I "$filterdir/tumor.pileups.table"
+						--matched-normal "$filterdir/normal.pileups.table"
+						-O "$filterdir/contamination.table"
+						--tumor-segmentation "$filterdir/tumorsegments.table"
+						--verbosity INFO
+						--tmp-dir "${tdirs[-1]}"
+				CMD
+				# --tumor-segmentation is removed i.e. deprecated since v4.6?
+			fi
 
 			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
-			commander::makecmd -a cmd9 -s ';' -c {COMMANDER[0]}<<- CMD
+			commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD
+				MALLOC_ARENA_MAX=4 gatk
+					--java-options '
+						-Xmx${jmem2}m
+						-XX:ParallelGCThreads=$jgct2
+						-XX:ConcGCThreads=$jcgct2
+						-Djava.io.tmpdir="$tmpdir"
+						-DGATK_STACKTRACE_ON_USER_EXCEPTION=true
+					'
+					LearnReadOrientationModel
+					$(printf -- '-I "%s" ' "${tomerge[@]/%/.f1r2.tar.gz}")
+					-O "$filterdir/f1r2_model.tar.gz"
+					--tmp-dir "${tdirs[-1]}"
+			CMD
+
+			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+			commander::makecmd -a cmd10 -s ';' -c {COMMANDER[0]}<<- CMD
 				MALLOC_ARENA_MAX=4 gatk
 					--java-options '
 						-Xmx${jmem2}m
@@ -516,19 +581,15 @@ function variants::mutect(){
 			CMD
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd10 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
+				commander::makecmd -a cmd12 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$t.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.$e" "$t.$e"
-				CMD
-
-				commander::makecmd -a cmd11 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 > "$o.$e.gz"
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
+				# sorting required to retain chromosomal order
 			done
 
 		done
@@ -546,18 +607,20 @@ function variants::mutect(){
 		commander::printcmd -a cmd9
 		commander::printcmd -a cmd10
 		commander::printcmd -a cmd11
+		commander::printcmd -a cmd12
 	else
 		commander::runcmd -c gatk -v -b -i $minstances -a cmd1
 		commander::runcmd -c gatk -v -b -i $minstances -a cmd2
-		commander::runcmd -c gatk -v -b -i $minstances -a cmd3
-		commander::runcmd -c gatk -v -b -i $minstances -a cmd4
-		commander::runcmd -c gatk -v -b -i $minstances -a cmd5
-		commander::runcmd -v -b -i $threads -a cmd6
+		commander::runcmd -c gatk -v -b -i $threads -a cmd3
+		commander::runcmd -c gatk -v -b -i $threads -a cmd4
+		commander::runcmd -c gatk -v -b -i $threads -a cmd5
+		commander::runcmd -c gatk -v -b -i $minstances -a cmd6
 		commander::runcmd -v -b -i $threads -a cmd7
 		commander::runcmd -v -b -i $threads -a cmd8
-		commander::runcmd -c gatk -v -b -i $minstances2 -a cmd9
-		commander::runcmd -v -b -i $threads -a cmd10
-		commander::runcmd -v -b -i $instances -a cmd11
+		commander::runcmd -v -b -i $threads -a cmd9
+		commander::runcmd -c gatk -v -b -i $threads -a cmd10
+		commander::runcmd -v -b -i $instances1 -a cmd11
+		commander::runcmd -v -b -i $instances2 -a cmd12
 	fi
 
 	return 0
@@ -607,42 +670,35 @@ function variants::bcftools(){
 	declare -n _bams_bcftools=$m
 	[[ ! $_tidx_bcftools ]] && unset _tidx_bcftools && declare -a _tidx_bcftools=(${!_bams_bcftools[@]}) # use all indices for germline calling
 
-	local ithreads i memory instances=$((${#_mapper_bcftools[@]}*${#_tidx_bcftools[@]}))
-	read -r i memory < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
+	local ignore instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_bcftools[@]}*${#_tidx_bcftools[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*threads*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
 
-	declare -a cmd1slice cmd2slice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
-	commander::makecmd -a cmd1slice -s ' ' -o "${tdirs[0]}/tmp" -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD
-		perl -lane '
-			$i=0;
-			for (map {$_*100000} 1..($F[1]-1)/100000){
-				$i=$_;
-				print join"\t",($F[0],$_-100000,$_-1);
-			}
-			print join"\t",($F[0],$i,$F[1]-1) if $i<$F[1]-1;
-		'
+	declare -a cmdslice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
+	commander::makecmd -a cmdslice -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+		bedtools makewindows
+			-g "$genome.fai"
+			-w 100000
+			-s $((100000-100))
+		> "${tdirs[0]}/tmp"
 	CMD
-		"$genome.fai"
-	CMD
-
-	commander::makecmd -a cmd2slice -s ' ' -c {COMMANDER[0]}<<- CMD
 		split
-		--numeric-suffixes=1
-		-a ${#threads}
-		-n l/$threads
-		--additional-suffix=.bed
-		--filter='bedtools merge -d 1 -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
-		"${tdirs[0]}/tmp" "${tdirs[0]}/x"
+			--numeric-suffixes=1
+			-a ${#threads}
+			-n l/$threads
+			--additional-suffix=.bed
+			--filter='bedtools merge -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
+			"${tdirs[0]}/tmp" "${tdirs[0]}/x"
 	CMD
+	# introduce padding across chunks
 
 	if $skip; then
-		commander::printcmd -a cmd1slice
-		commander::printcmd -a cmd2slice
+		commander::printcmd -a cmdslice
 	else
-		commander::runcmd -v -b -i $threads -a cmd1slice
-		commander::runcmd -v -b -i $threads -a cmd2slice
+		commander::runcmd -v -b -i $threads -a cmdslice
 	fi
-
 
 	local m i j f nf o t e slice odir tdir
 	declare -a tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6
@@ -769,20 +825,22 @@ function variants::bcftools(){
 					CMD
 				fi
 
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
+					commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
 				tomerge+=("$slice")
 			done
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
-				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.$e" "$t.$e"
-				CMD
-
+				# removes potential duplicates due to padding
 				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
@@ -802,8 +860,8 @@ function variants::bcftools(){
 		commander::runcmd -v -b -i $threads -a cmd2
 		commander::runcmd -v -b -i $threads -a cmd3
 		commander::runcmd -v -b -i $threads -a cmd4
-		commander::runcmd -v -b -i $threads -a cmd5
-		commander::runcmd -v -b -i $instances -a cmd6
+		commander::runcmd -v -b -i $instances1 -a cmd5
+		commander::runcmd -v -b -i $instances2 -a cmd6
 	fi
 
 	return 0
@@ -853,43 +911,35 @@ function variants::freebayes(){
 	declare -n _bams_freebayes=$m
 	[[ ! $_tidx_freebayes ]] && unset _tidx_freebayes && declare -a _tidx_freebayes=(${!_bams_freebayes[@]}) # use all indices for germline calling
 
-	local ithreads i memory instances=$((${#_mapper_freebayes[@]}*${#_tidx_freebayes[@]}))
-	read -r i memory < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
+	local ignore instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_freebayes[@]}*${#_tidx_freebayes[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*threads*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
 
-	declare -a cmd1slice cmd2slice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
-
-	commander::makecmd -a cmd1slice -s ' ' -o "${tdirs[0]}/tmp" -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD
-		perl -lane '
-			$i=0;
-			for (map {$_*100000} 1..($F[1]-1)/100000){
-				$i=$_;
-				print join"\t",($F[0],$_-100000,$_-1);
-			}
-			print join"\t",($F[0],$i,$F[1]-1) if $i<$F[1]-1;
-		'
+	declare -a cmdslice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
+	commander::makecmd -a cmdslice -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+		bedtools makewindows
+			-g "$genome.fai"
+			-w 100000
+			-s $((100000-100))
+		> "${tdirs[0]}/tmp"
 	CMD
-		"$genome.fai"
-	CMD
-
-	commander::makecmd -a cmd2slice -s ' ' -c {COMMANDER[0]}<<- CMD
 		split
-		--numeric-suffixes=1
-		-a ${#threads}
-		-n l/$threads
-		--additional-suffix=.bed
-		--filter='bedtools merge -d 1 -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
-		"${tdirs[0]}/tmp" "${tdirs[0]}/x"
+			--numeric-suffixes=1
+			-a ${#threads}
+			-n l/$threads
+			--additional-suffix=.bed
+			--filter='bedtools merge -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
+			"${tdirs[0]}/tmp" "${tdirs[0]}/x"
 	CMD
+	# introduce padding
 
 	if $skip; then
-		commander::printcmd -a cmd1slice
-		commander::printcmd -a cmd2slice
+		commander::printcmd -a cmdslice
 	else
-		commander::runcmd -v -b -i $threads -a cmd1slice
-		commander::runcmd -v -b -i $threads -a cmd2slice
+		commander::runcmd -v -b -i $threads -a cmdslice
 	fi
-
 
 	local m i j f nf o t e slice odir tdir
 	declare -a tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6
@@ -987,20 +1037,22 @@ function variants::freebayes(){
 					CMD
 				fi
 
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.freebayes)")
+					commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
 				tomerge+=("$slice")
 			done
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
-				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.$e" "$t.$e"
-				CMD
-
+				# removes potential duplicates due to padding
 				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
@@ -1020,8 +1072,8 @@ function variants::freebayes(){
 		commander::runcmd -v -b -i $threads -a cmd2
 		commander::runcmd -v -b -i $threads -a cmd3
 		commander::runcmd -v -b -i $threads -a cmd4
-		commander::runcmd -v -b -i $threads -a cmd5
-		commander::runcmd -v -b -i $instances -a cmd6
+		commander::runcmd -v -b -i $instances1 -a cmd5
+		commander::runcmd -v -b -i $instances2 -a cmd6
 	fi
 
 	return 0
@@ -1034,7 +1086,6 @@ function variants::varscan(){
 			-S <hardskip>  | true/false return
 			-s <softskip>  | true/false only print commands
 			-t <threads>   | number of
-			-m <memory>    | per threads amount of (default: 2048)
 			-M <maxmemory> | amount of
 			-g <genome>    | path to
 			-d <dbsnp>     | path to
@@ -1048,12 +1099,11 @@ function variants::varscan(){
 
 	local OPTIND arg mandatory skip=false threads memory maxmemory genome dbsnp tmpdir="${TMPDIR:-/tmp}" outdir
 	declare -n _mapper_varscan _nidx_varscan _tidx_varscan
-	while getopts 'S:s:t:M:g:d:m:r:1:2:c:o:' arg; do
+	while getopts 'S:s:t:M:g:d:r:1:2:c:o:' arg; do
 		case $arg in
 			S) $OPTARG && return 0;;
 			s) $OPTARG && skip=true;;
 			t) ((++mandatory)); threads=$OPTARG;;
-			m) memory=$OPTARG;;
 			M) maxmemory=$OPTARG;;
 			g) ((++mandatory)); genome="$OPTARG";;
 			d) dbsnp="$OPTARG";;
@@ -1073,45 +1123,36 @@ function variants::varscan(){
 	declare -n _bams_varscan=$m
 	[[ ! $_tidx_varscan ]] && unset _tidx_varscan && declare -a _tidx_varscan=(${!_bams_varscan[@]}) # use all indices for germline calling
 
-	local minstances mthreads jmem jgct jcgct ithreads i memory1 memory2 instances=$((${#_mapper_varscan[@]}*${#_tidx_varscan[@]}))
-	read -r minstances mthreads jmem jgct jcgct < <(configure::jvm -T $threads -m ${memory:-2048} -M "$maxmemory") # good estimate for varscan
-	read -r i memory1 < <(configure::memory_by_instances -i $((minstances*instances)) -T $threads -M "$maxmemory") # for bcftools sort of initial vcf slices
-	read -r i memory2 < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
+	local ignore jmem jgct jcgct instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_varscan[@]}*${#_tidx_varscan[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r ignore ignore jmem jgct jcgct < <(configure::jvm -T $threads -M "$maxmemory")
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*threads*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
 
-	declare -a cmd1slice cmd2slice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
-
-	commander::makecmd -a cmd1slice -s ' ' -o "${tdirs[0]}/tmp" -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD
-		perl -lane '
-			$i=0;
-			for (map {$_*100000} 1..($F[1]-1)/100000){
-				$i=$_;
-				print join"\t",($F[0],$_-100000,$_-1);
-			}
-			print join"\t",($F[0],$i,$F[1]-1) if $i<$F[1]-1;
-		'
+	declare -a cmdslice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
+	commander::makecmd -a cmdslice -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+		bedtools makewindows
+			-g "$genome.fai"
+			-w 100000
+			-s $((100000-100))
+		> "${tdirs[-1]}/tmp"
 	CMD
-		"$genome.fai"
-	CMD
-
-	commander::makecmd -a cmd2slice -s ' ' -c {COMMANDER[0]}<<- CMD
 		split
-		--numeric-suffixes=1
-		-a ${#minstances}
-		-n l/$minstances
-		--additional-suffix=.bed
-		--filter='bedtools merge -d 1 -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
-		"${tdirs[0]}/tmp" "${tdirs[0]}/x"
+			--numeric-suffixes=1
+			-a ${#threads}
+			-n l/$threads
+			--additional-suffix=.bed
+			--filter='bedtools merge -i - > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
+			"${tdirs[0]}/tmp" "${tdirs[0]}/x"
 	CMD
+	# introduce padding
 
 	if $skip; then
-		commander::printcmd -a cmd1slice
-		commander::printcmd -a cmd2slice
+		commander::printcmd -a cmdslice
 	else
-		commander::runcmd -v -b -i $threads -a cmd1slice
-		commander::runcmd -v -b -i $threads -a cmd2slice
+		commander::runcmd -v -b -i $threads -a cmdslice
 	fi
-
 
 	local m i j f nf o t e slice odir tdir
 	declare -a tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6 cmd7 cmd8
@@ -1128,7 +1169,7 @@ function variants::varscan(){
 			o="$odir/${o%.*}"
 			tomerge=()
 
-			for j in $(seq 1 $minstances); do
+			for j in $(seq 1 $threads); do
 				slice="$t.slice.$j"
 
 				if [[ $_nidx_varscan ]]; then # somatic
@@ -1168,20 +1209,34 @@ function variants::varscan(){
 							--output-indel "$slice.indel"
 							--output-vcf 1
 					CMD
+					# all sites are labeled with PASS
+					# do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if SS=2
 
-					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-					# do not use bcftools concat -o "$slice.concat" "$slice.snp.reheader" "$slice.indel.reheader", since positions can overlap which is not handled by bcftools unless input is bgzip
-					commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
-						bcftools reheader -f "$genome.fai" -o "$slice.snp.reheader" "$slice.snp.vcf"
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
+					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						awk -v OFS='\t' '$7=="PASS"{$7="."}{print}'
 					CMD
-						bcftools reheader -f "$genome.fai" -o "$slice.indel.reheader" "$slice.indel.vcf"
+						"$slice.snp.vcf" > "$slice.snp.toreheader";
 					CMD
-						cat <(bcftools view -h "$slice.snp.reheader") <(bcftools view -H "$slice.snp.reheader" | awk -v OFS='\t' '{\$7="."; print}') <(bcftools view -H "$slice.indel.reheader" | awk -v OFS='\t' '{\$7="."; print}') > "$slice.concat"
+						bcftools reheader -f "$genome.fai" "$slice.snp.toreheader" | bgzip -k -c -@ $ithreads1 > "$slice.snp.vcf.gz";
 					CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${memory1}M -o "$slice.vcf" "$slice.concat"
+						tabix -f -p vcf "$slice.snp.vcf.gz"
 					CMD
-					#	grep -E '(^#|SS=2)' "$slice.unfiltered" > "$slice.vcf"
-					#CMD # do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if SS=2
+
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
+					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						awk -v OFS='\t' '$7=="PASS"{$7="."}{print}'
+					CMD
+						"$slice.indel.vcf" > "$slice.indel.toreheader";
+					CMD
+						bcftools reheader -f "$genome.fai" "$slice.indel.toreheader" | bgzip -k -c -@ $ithreads1 > "$slice.indel.vcf.gz";
+					CMD
+						tabix -f -p vcf "$slice.indel.vcf.gz"
+					CMD
+
+					commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
+						bcftools concat --threads $ithreads1 -a -d all -o "$slice.vcf" "$slice.snp.vcf.gz" "$slice.indel.vcf.gz"
+					CMD
 				else
 					commander::makecmd -a cmd1 -s ';' -c {COMMANDER[0]}<<- CMD
 						samtools mpileup
@@ -1212,28 +1267,29 @@ function variants::varscan(){
 							--output-vcf 1
 							--variants 1
 					CMD
-						awk -v OFS='\t' '{if($7=="PASS"){$7="."}; print}'
+						awk -v OFS='\t' '$7=="PASS"{$7="."}{print}'
 					CMD
 					# all sites are labeled with PASS
 
 					# do not pipe into bcftools : --fai cannot be used when reading from stdin
-					commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
+					commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
 						bcftools reheader -f "$genome.fai" -o "$slice.vcf" "$slice.toreheader"
 					CMD
 				fi
 
-				commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
+				commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD
 					vcfix.pl -i "$slice.vcf" > "$slice.fixed.vcf"
 				CMD
 
-				commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+				commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools norm -f "$genome" -c s -m-both "$slice.fixed.vcf"
 				CMD
 					vcfix.pl -i - > "$slice.fixed.nomulti.vcf"
 				CMD
 
 				if [[ $dbsnp ]]; then
-					commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
+					commander::makecmd -a cmd7 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
 						vcffixup "$slice.fixed.nomulti.vcf"
 					CMD
 						vt normalize -q -n -r "$genome" -
@@ -1245,7 +1301,7 @@ function variants::varscan(){
 						vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$slice.fixed.nomulti.normed.nodbsnp.vcf"
 					CMD
 				else
-					commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					commander::makecmd -a cmd7 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
 						vcffixup "$slice.fixed.nomulti.vcf"
 					CMD
 						vt normalize -q -n -r "$genome" -
@@ -1254,20 +1310,22 @@ function variants::varscan(){
 					CMD
 				fi
 
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
+					commander::makecmd -a cmd8 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
 				tomerge+=("$slice")
 			done
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
-				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory2}M -o "$o.$e" "$t.$e"
-				CMD
-
-				commander::makecmd -a cmd8 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+				# removes potential duplicates due to padding
+				commander::makecmd -a cmd9 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
@@ -1284,15 +1342,17 @@ function variants::varscan(){
 		commander::printcmd -a cmd6
 		commander::printcmd -a cmd7
 		commander::printcmd -a cmd8
+		commander::printcmd -a cmd9
 	else
 		commander::runcmd -v -b -i $threads -a cmd1
-		commander::runcmd -c varscan -v -b -i $minstances -a cmd2
-		commander::runcmd -v -b -i $threads -a cmd3
-		commander::runcmd -v -b -i $threads -a cmd4
+		commander::runcmd -c varscan -v -b -i $threads -a cmd2
+		commander::runcmd -v -b -i $instances1 -a cmd3
+		commander::runcmd -v -b -i $instances1 -a cmd4
 		commander::runcmd -v -b -i $threads -a cmd5
 		commander::runcmd -v -b -i $threads -a cmd6
 		commander::runcmd -v -b -i $threads -a cmd7
-		commander::runcmd -v -b -i $instances -a cmd8
+		commander::runcmd -v -b -i $instances1 -a cmd8
+		commander::runcmd -v -b -i $instances2 -a cmd9
 	fi
 
 	return 0
@@ -1305,7 +1365,6 @@ function variants::vardict(){
 			-S <hardskip>  | true/false return
 			-s <softskip>  | true/false only print commands
 			-t <threads>   | number of
-			-m <memory>    | per thread amount of (default: 12288)
 			-M <maxmemory> | amount of
 			-g <genome>    | path to
 			-d <dbsnp>     | path to
@@ -1319,12 +1378,11 @@ function variants::vardict(){
 
 	local OPTIND arg mandatory skip=false threads memory maxmemory genome dbsnp tmpdir="${TMPDIR:-/tmp}" outdir
 	declare -n _mapper_vardict _nidx_vardict _tidx_vardict
-	while getopts 'S:s:t:M:g:d:m:r:1:2:c:o:' arg; do
+	while getopts 'S:s:t:M:g:d:r:1:2:c:o:' arg; do
 		case $arg in
 			S) $OPTARG && return 0;;
 			s) $OPTARG && skip=true;;
 			t) ((++mandatory)); threads=$OPTARG;;
-			m) memory=$OPTARG;;
 			M) maxmemory=$OPTARG;;
 			g) ((++mandatory)); genome="$OPTARG";;
 			d) dbsnp="$OPTARG";;
@@ -1344,53 +1402,43 @@ function variants::vardict(){
 	declare -n _bams_vardict=$m
 	[[ ! $_tidx_vardict ]] && unset _tidx_vardict && declare -a _tidx_vardict=(${!_bams_vardict[@]}) # use all indices for germline calling
 
-	local minstances mthreads jmem jgct jcgct ithreads i memory1 memory2 instances=$((${#_mapper_vardict[@]}*${#_tidx_vardict[@]}))
-	read -r minstances mthreads jmem jgct jcgct < <(configure::jvm -T $threads -m ${memory:=12288} -M "$maxmemory")
+	local ignore jmem jgct jcgct ithreads instances1 ithreads1 imemory1 instances2 ithreads2 imemory2
+	local n=3 instances=$((${#_mapper_vardict[@]}*${#_tidx_vardict[@]}))
+	[[ $dbsnp ]] && n=4
+	read -r ignore ignore jmem jgct jcgct < <(configure::jvm -T $threads -M "$maxmemory")
+	read -r instances1 ithreads1 imemory1 ignore < <(configure::jvm -i $((instances*threads*n)) -t 10 -T $threads -M "$maxmemory") # for slice wise bcftools sort + bgzip
+	read -r instances2 ithreads2 imemory2 ignore < <(configure::jvm -i $((instances*n)) -t 10 -T $threads -M "$maxmemory") # for final bcftools concat of all 4 vcf files
+
+	declare -a cmdslice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
+
+	commander::makecmd -a cmdslice -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+		bedtools makewindows
+			-g "$genome.fai"
+			-w $((jmem>12000?10000:jmem<3000?1000:jmem-2000))
+			-s $((jmem>12000?10000-100:jmem<3000?1000-100:jmem-2000-100))
+		> "${tdirs[-1]}/tmp"
+	CMD
+		split
+			--numeric-suffixes=1
+			-a ${#threads}
+			-n l/$threads
+			--additional-suffix=.bed
+			--filter='cat > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
+			"${tdirs[0]}/tmp" "${tdirs[0]}/x"
+	CMD
 	# I often estimate needed memory by about 1Mb for 1 bp of region (here are included possible intermediate structures for variations, reference and softclips).
 	# Also you have to take account of amount of threads that you run, because memory will be used by all of them and will be split between threads
 	# https://github.com/AstraZeneca-NGS/VarDictJava/issues/216
-	# -> 10kb chunks -> 10G per thread + JVM overhead by GC
-	read -r i memory1 < <(configure::memory_by_instances -i $((minstances*instances)) -T $threads -M "$maxmemory") # for bcftools sort of initial vcf slices
-	read -r i memory2 < <(configure::memory_by_instances -i $((instances*4)) -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
-
-	declare -a cmd1slice cmd2slice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
-
-	commander::makecmd -a cmd1slice -s ' ' -o "${tdirs[0]}/tmp" -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD
-		perl -M'List::Util qw(max)' -slane '
-			$l = $m-2048 >= 9500 ? 10000 : int(($m-1024)/1000)*1000;
-			$i=0;
-			for (map {$_*$l} 1..($F[1]-1)/$l){
-				$i=$_;
-				print join"\t",($F[0],max(0,$_-$l-100),$_-1);
-			}
-			print join"\t",($F[0],$i-100,$F[1]-1) if $i<$F[1]-1;
-		'
-	CMD
-		-- -m=$jmem "$genome.fai"
-	CMD
 	# despite of mutlithreading support, execute in parallel on multiple chunks, to limit memory footprint which heavily depends on region size and coverage.
-	# small chunks within one bed file wille be individually processed. thus a small overlap is recommended to no miss any variant.
-	# overlaps will by internally handled -> https://github.com/AstraZeneca-NGS/VarDictJava/issues/64
-
-	commander::makecmd -a cmd2slice -s ' ' -c {COMMANDER[0]}<<- CMD
-		split
-		--numeric-suffixes=1
-		-a ${#minstances}
-		-n l/$minstances
-		--additional-suffix=.bed
-		--filter='cat > "\$(dirname "\$FILE")/"\$(basename "\$FILE" | sed "s/^x0*/slice./")'
-		"${tdirs[0]}/tmp" "${tdirs[0]}/x"
-	CMD
+	# 1k region ~ 1gb memory + 2gb by java + tool itself
+	# small chunks within one bed file will be individually processed. thus a small overlap is recommended to not miss any variant.
+	# overlaps will by internally handled by var2vcf_paired.pl. see https://github.com/AstraZeneca-NGS/VarDictJava/issues/64
 
 	if $skip; then
-		commander::printcmd -a cmd1slice
-		commander::printcmd -a cmd2slice
+		commander::printcmd -a cmdslice
 	else
-		commander::runcmd -v -b -i $threads -a cmd1slice
-		commander::runcmd -v -b -i $threads -a cmd2slice
+		commander::runcmd -v -b -i $threads -a cmdslice
 	fi
-
 
 	local m i j f nf o t e slice odir tdir
 	declare -a tomerge cmd1 cmd2 cmd3 cmd4 cmd5 cmd6 cmd7
@@ -1407,7 +1455,7 @@ function variants::vardict(){
 			o="$odir/${o%.*}"
 			tomerge=()
 
-			for j in $(seq 1 $minstances); do
+			for j in $(seq 1 $threads); do
 				slice="$t.slice.$j"
 
 				if [[ $_nidx_vardict ]]; then # somatic
@@ -1415,7 +1463,7 @@ function variants::vardict(){
 					# prefer -fisher option (vardict skips corrupt sites) over vardict | testsomatic.R | var2vcf_paired.pl , due to R: Error in fisher.test
 					# use -X 0 to not combine snps within 3 bp window into indel or complex, which in addiation reduces the risk of StringIndexOutOfBoundsException
 					# vardict will fail upon > 10 errors per region
-					commander::makecmd -a cmd1 -s '|' -o "$slice.vcf" -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- 'CMD'
+					commander::makecmd -a cmd1 -s '|' -o "$slice.toreheader" -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- 'CMD'
 						MALLOC_ARENA_MAX=4
 						JAVA_OPTS="-Xmx${jmem}m -XX:ParallelGCThreads=$jgct -XX:ConcGCThreads=$jcgct -Djava.io.tmpdir='$tmpdir' -DGATK_STACKTRACE_ON_USER_EXCEPTION=true"
 						vardict-java
@@ -1447,7 +1495,7 @@ function variants::vardict(){
 							-A
 							-N "TUMOR|NORMAL"
 					CMD
-						awk -v OFS='\t' '{if(/^#CHROM/){s=1}; if(s){t=$11; $11=$10; $10=t}; print}'
+						awk -v OFS='\t' '/^#CHROM/{s=1}; s==1{t=$11; $11=$10; $10=t} {print}'
 					CMD
 					#	grep -E '(^#|STATUS=[^;]*[sS]omatic)' > "$slice.vcf"
 					#CMD # do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if STATUS=[^;]*[sS]omatic
@@ -1483,18 +1531,18 @@ function variants::vardict(){
 							-A
 							-E
 							-N SAMPLE
-						> "$slice.vcf"
+						> "$slice.toreheader"
 					CMD
 				fi
 				# -A print all variants at the same site. otherwise reported one is chosen by MAF.
 				# note: this does not always mean multiple alleles per se (like bcftools norm), but sometimes duplicons with slightly differnt format and info fields
 
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools reheader -f "$genome.fai" -o "$slice.reheader" "$slice.vcf"
+				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.vardict)")
+				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD
+					bcftools reheader -f "$genome.fai" -o "$slice.vcf" "$slice.toreheader"
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory1}M -o "$slice.vcf" "$slice.reheader"
-				CMD
+				# 	bcftools sort -T "${tdirs[-1]}" -m ${memory1}M -o "$slice.vcf" "$slice.reheadered"
+				# CMD
 
 				commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
 					vcfix.pl -i "$slice.vcf" > "$slice.fixed.vcf"
@@ -1528,20 +1576,22 @@ function variants::vardict(){
 					CMD
 				fi
 
+				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
+					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.vardict)")
+					commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					CMD
+						tabix -f -p vcf "$slice.$e.gz"
+					CMD
+				done
+
 				tomerge+=("$slice")
 			done
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-				#DO NOT PIPE - DATALOSS!
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat -o "$t.$e" $(printf '"%s" ' "${tomerge[@]/%/.$e}")
-				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory2}M -o "$o.$e" "$t.$e"
-				CMD
-
+				# removes potential duplicates due to padding
 				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
 					tabix -f -p vcf "$o.$e.gz"
 				CMD
@@ -1558,13 +1608,13 @@ function variants::vardict(){
 		commander::printcmd -a cmd6
 		commander::printcmd -a cmd7
 	else
-		commander::runcmd -c vardict -v -b -i $minstances -a cmd1
+		commander::runcmd -c vardict -v -b -i $threads -a cmd1
 		commander::runcmd -v -b -i $threads -a cmd2
 		commander::runcmd -v -b -i $threads -a cmd3
 		commander::runcmd -v -b -i $threads -a cmd4
 		commander::runcmd -v -b -i $threads -a cmd5
-		commander::runcmd -v -b -i $threads -a cmd6
-		commander::runcmd -v -b -i $instances -a cmd7
+		commander::runcmd -v -b -i $instances1 -a cmd6
+		commander::runcmd -v -b -i $instances2 -a cmd7
 	fi
 
 	return 0
@@ -1618,31 +1668,26 @@ function variants::vardict_threads(){
 	declare -n _bams_vardict=$m
 	[[ ! $_tidx_vardict ]] && unset _tidx_vardict && declare -a _tidx_vardict=(${!_bams_vardict[@]}) # use all indices for germline calling
 
-	local minstances mthreads jmem jgct jcgct ithreads i memory instances=$((${#_mapper_vardict[@]}*${#_tidx_vardict[@]}))
-	read -r minstances mthreads jmem jgct jcgct < <(configure::jvm -i 1 -T $threads -M "$maxmemory")
-	read -r i memory < <(configure::memory_by_instances -i $instances -T $threads -M "$maxmemory") # for final bcftools sort of vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf
-	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
+	local ignore jmem jgct jcgct ithreads imemory instances=$((${#_mapper_vardict[@]}*${#_tidx_vardict[@]}))
+	read -r ignore ignore jmem jgct jcgct < <(configure::jvm -T $threads -M "$maxmemory")
+	read -r ignore imemory < <(configure::memory_by_instances -i $instances -T $threads -M "$maxmemory")
+	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads)
 
-	declare -a cmd1slice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
+	declare -a cmdslice tdirs=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bed)")
 
-	commander::makecmd -a cmd1slice -s ' ' -o "${tdirs[0]}/regions.bed" -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD
-		perl -M'List::Util qw(max)' -lane '
-			$i=0;
-			for (map {$_*10000} 1..($F[1]-1)/10000){
-				$i=$_;
-				print join"\t",($F[0],max(0,$_-10000-100),$_-1);
-			}
-			print join"\t",($F[0],$i-100,$F[1]-1) if $i<$F[1]-1;
-		'
+	commander::makecmd -a cmdslice -s ' ' -c {COMMANDER[0]}<<- CMD
+		bedtools makewindows
+			-g "$genome.fai"
+			-w $((jmem/threads>12000?10000:jmem/threads<3000?1000:jmem/threads-2000))
+			-s $((jmem/threads>12000?10000-100:jmem/threads<3000?1000-100:jmem/threads-2000-100))
+		> "${tdirs[-1]}/regions.bed"
 	CMD
-		"$genome.fai"
-	CMD
-	# TODO either do chunks depending on jmem/threads or restrict -th parameter to maxmem/jmem
+	# due to 1 instance jmem inferred as max avail mem. i.e. chunk size (1kb~1gb per threads) is jmem/threads
 
 	if $skip; then
-		commander::printcmd -a cmd1slice
+		commander::printcmd -a cmdslice
 	else
-		commander::runcmd -v -b -i $threads -a cmd1slice
+		commander::runcmd -v -b -i $threads -a cmdslice
 	fi
 
 	local m i f nf o t e odir tdir
@@ -1739,11 +1784,11 @@ function variants::vardict_threads(){
 			# -A print all variants at the same site. otherwise reported one is chosen by MAF.
 			# note: this does not always mean multiple alleles per se (like bcftools norm), but sometimes duplicons with slightly differnt format and info fields
 
-			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
+			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.vardict)")
 			commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 				bcftools reheader -f "$genome.fai" -o "$t.vcf" "$t.toreheader"
 			CMD
-				bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.vcf" "$t.vcf"
+				bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
 			CMD
 
 			commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
@@ -1851,8 +1896,8 @@ function variants::platypus(){
 	declare -n _bams_platypus=$m
 	[[ ! $_tidx_platypus ]] && unset _tidx_platypus && declare -a _tidx_platypus=(${!_bams_platypus[@]}) # use all indices for germline calling
 
-	local ithreads memory i instances=$((${#_mapper_platypus[@]}*${#_tidx_platypus[@]}))
-	read -r i memory < <(configure::memory_by_instances -i $instances -T $threads -M "$maxmemory")
+	local ignore ithreads imemory instances=$((${#_mapper_platypus[@]}*${#_tidx_platypus[@]}))
+	read -r ignore imemory < <(configure::memory_by_instances -i $instances -T $threads -M "$maxmemory")
 	read -r instances ithreads < <(configure::instances_by_threads -i $instances -t 10 -T $threads) # for final bgzip
 
 	local m i f nf o t e odir tdir
@@ -1869,7 +1914,7 @@ function variants::platypus(){
 			t="$tdir/${o%.*}"
 			o="$odir/${o%.*}"
 			echo "rm -f '$t'*" >> "$BASHBONE_CLEANUP"
-			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
+			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.platypus)")
 
 			# can make use of --regions=$(awk '{print $1":"$2"-"$3}' $bed | xargs -echo | sed 's/ /,/g')
 			if [[ $_nidx_platypus ]]; then # somatic
@@ -1900,7 +1945,7 @@ function variants::platypus(){
 				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools reheader -f "$genome.fai" "$t.toreheader" | vcfsamplediff VCFSAMPLEDIFF NORMAL TUMOR - > "$t.vcf"
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.vcf" "$t.vcf"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
 				CMD
 				#	grep -E '(^#|VCFSAMPLEDIFF=somatic)' > "$o.vcf"
 				#CMD # do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if somatic or loh and GQ MAF thresholds passed
@@ -1928,7 +1973,7 @@ function variants::platypus(){
 				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools reheader -f "$genome.fai" -o "$t.vcf" "$t.toreheader"
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${memory}M -o "$o.vcf" "$t.vcf"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
 				CMD
 			fi
 

--- a/lib/variants_2.sh
+++ b/lib/variants_2.sh
@@ -199,10 +199,14 @@ function variants::haplotypecaller(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
-					commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -211,12 +215,10 @@ function variants::haplotypecaller(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
-				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools concat --threads $ithreads2 -O z -a -d all -o "$t.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 > "$o.$e.gz"
-				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 | tee -i "$o.$e.gz" | bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 				# sorting required to retain chromosomal order
 			done
@@ -481,10 +483,14 @@ function variants::mutect(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
-					commander::makecmd -a cmd11 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd11 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -582,12 +588,10 @@ function variants::mutect(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.gatk)")
-				commander::makecmd -a cmd12 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+				commander::makecmd -a cmd12 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
 					bcftools concat --threads $ithreads2 -O z -a -d all -o "$t.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 > "$o.$e.gz"
-				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory2}M "$t.$e.gz" | bgzip -k -c -@ $ithreads2 | tee -i "$o.$e.gz" | bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 				# sorting required to retain chromosomal order
 			done
@@ -827,10 +831,14 @@ function variants::bcftools(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.bcftools)")
-					commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -839,10 +847,12 @@ function variants::bcftools(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				# removes potential duplicates due to padding
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
+				commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done
@@ -1039,10 +1049,14 @@ function variants::freebayes(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.freebayes)")
-					commander::makecmd -a cmd5 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -1051,10 +1065,12 @@ function variants::freebayes(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				# removes potential duplicates due to padding
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
+				commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done
@@ -1213,25 +1229,21 @@ function variants::varscan(){
 					# do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if SS=2
 
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
-					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
 						awk -v OFS='\t' '$7=="PASS"{$7="."}{print}'
 					CMD
 						"$slice.snp.vcf" > "$slice.snp.toreheader";
 					CMD
-						bcftools reheader -f "$genome.fai" "$slice.snp.toreheader" | bgzip -k -c -@ $ithreads1 > "$slice.snp.vcf.gz";
-					CMD
-						tabix -f -p vcf "$slice.snp.vcf.gz"
+						bcftools reheader -f "$genome.fai" "$slice.snp.toreheader" | bgzip -k -c -@ $ithreads1 | tee -i "$slice.snp.vcf.gz" | bcftools index --threads $ithreads1 -f -t -o "$slice.snp.vcf.gz.tbi"
 					CMD
 
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
-					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+					commander::makecmd -a cmd3 -s ' ' -c {COMMANDER[0]}<<- 'CMD' {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
 						awk -v OFS='\t' '$7=="PASS"{$7="."}{print}'
 					CMD
 						"$slice.indel.vcf" > "$slice.indel.toreheader";
 					CMD
-						bcftools reheader -f "$genome.fai" "$slice.indel.toreheader" | bgzip -k -c -@ $ithreads1 > "$slice.indel.vcf.gz";
-					CMD
-						tabix -f -p vcf "$slice.indel.vcf.gz"
+						bcftools reheader -f "$genome.fai" "$slice.indel.toreheader" | bgzip -k -c -@ $ithreads1 | tee -i "$slice.indel.vcf.gz" | bcftools index --threads $ithreads1 -f -t -o "$slice.indel.vcf.gz.tbi"
 					CMD
 
 					commander::makecmd -a cmd4 -s ';' -c {COMMANDER[0]}<<- CMD
@@ -1312,10 +1324,14 @@ function variants::varscan(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.varscan)")
-					commander::makecmd -a cmd8 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd8 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -1324,10 +1340,12 @@ function variants::varscan(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				# removes potential duplicates due to padding
-				commander::makecmd -a cmd9 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
+				commander::makecmd -a cmd9 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done
@@ -1578,10 +1596,14 @@ function variants::vardict(){
 
 				for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 					tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.vardict)")
-					commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e" | bgzip -k -c -@ $ithreads1 > "$slice.$e.gz"
+					commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD
+						bcftools sort -T "${tdirs[-1]}" -m ${imemory1}M "$slice.$e"
 					CMD
-						tabix -f -p vcf "$slice.$e.gz"
+						bgzip -k -c -@ $ithreads1
+					CMD
+						tee -i "$slice.$e.gz"
+					CMD
+						bcftools index --threads $ithreads1 -f -t -o "$slice.$e.gz.tbi"
 					CMD
 				done
 
@@ -1590,10 +1612,12 @@ function variants::vardict(){
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
 				# removes potential duplicates due to padding
-				commander::makecmd -a cmd7 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools concat --threads $ithreads2 -O z -a -d all -o "$o.$e.gz" $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
+				commander::makecmd -a cmd7 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bcftools concat --threads $ithreads2 -O z -a -d all $(printf '"%s" ' "${tomerge[@]/%/.$e.gz}")
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads2 -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done
@@ -1786,48 +1810,50 @@ function variants::vardict_threads(){
 
 			tdirs+=("$(mktemp -d -p "$tmpdir" cleanup.XXXXXXXXXX.vardict)")
 			commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-				bcftools reheader -f "$genome.fai" -o "$t.vcf" "$t.toreheader"
+				bcftools reheader -f "$genome.fai" -o "$t.reheadered" "$t.toreheader"
 			CMD
-				bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
+				bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$t.vcf" "$t.reheadered"
 			CMD
 
 			commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
-				vcfix.pl -i "$o.vcf" > "$o.fixed.vcf"
+				vcfix.pl -i "$t.vcf" > "$t.fixed.vcf"
 			CMD
 
 			commander::makecmd -a cmd4 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-				bcftools norm -f "$genome" -c s -m-both "$o.fixed.vcf"
+				bcftools norm -f "$genome" -c s -m-both "$t.fixed.vcf"
 			CMD
-				vcfix.pl -i - > "$o.fixed.nomulti.vcf"
+				vcfix.pl -i - > "$t.fixed.nomulti.vcf"
 			CMD
 
 			if [[ $dbsnp ]]; then
 				commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
-					vcffixup "$o.fixed.nomulti.vcf"
+					vcffixup "$t.fixed.nomulti.vcf"
 				CMD
 					vt normalize -q -n -r "$genome" -
 				CMD
 					vcfixuniq.pl
 				CMD
-					tee -i "$o.fixed.nomulti.normed.vcf"
+					tee -i "$t.fixed.nomulti.normed.vcf"
 				CMD
-					vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$o.fixed.nomulti.normed.nodbsnp.vcf"
+					vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$t.fixed.nomulti.normed.nodbsnp.vcf"
 				CMD
 			else
 				commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
-					vcffixup "$o.fixed.nomulti.vcf"
+					vcffixup "$t.fixed.nomulti.vcf"
 				CMD
 					vt normalize -q -n -r "$genome" -
 				CMD
-					vcfixuniq.pl > "$o.fixed.nomulti.normed.vcf"
+					vcfixuniq.pl > "$t.fixed.nomulti.normed.vcf"
 				CMD
 			fi
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+				commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bgzip -k -c -@ $ithreads "$t.$e"
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done
@@ -1943,9 +1969,9 @@ function variants::platypus(){
 				# use to filter for germline risk
 				# do not use --strict, which requires that no observation in the germline support the somatic alternate i.e. no 0/1 0/1
 				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools reheader -f "$genome.fai" "$t.toreheader" | vcfsamplediff VCFSAMPLEDIFF NORMAL TUMOR - > "$t.vcf"
+					bcftools reheader -f "$genome.fai" "$t.toreheader" | vcfsamplediff VCFSAMPLEDIFF NORMAL TUMOR - > "$t.reheadered"
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$t.vcf" "$t.reheadered"
 				CMD
 				#	grep -E '(^#|VCFSAMPLEDIFF=somatic)' > "$o.vcf"
 				#CMD # do not hard filter here. vcfix.pl adds vcfix_somatic FILTER tag if somatic or loh and GQ MAF thresholds passed
@@ -1971,49 +1997,51 @@ function variants::platypus(){
 				CMD
 
 				commander::makecmd -a cmd2 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bcftools reheader -f "$genome.fai" -o "$t.vcf" "$t.toreheader"
+					bcftools reheader -f "$genome.fai" -o "$t.reheadered" "$t.toreheader"
 				CMD
-					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$o.vcf" "$t.vcf"
+					bcftools sort -T "${tdirs[-1]}" -m ${imemory}M -o "$t.vcf" "$t.reheadered"
 				CMD
 			fi
 
 			commander::makecmd -a cmd3 -s ';' -c {COMMANDER[0]}<<- CMD
-				vcfix.pl -i "$o.vcf" > "$o.fixed.vcf"
+				vcfix.pl -i "$t.vcf" > "$t.fixed.vcf"
 			CMD
 
 			commander::makecmd -a cmd4 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-				bcftools norm -f "$genome" -c s -m-both "$o.fixed.vcf"
+				bcftools norm -f "$genome" -c s -m-both "$t.fixed.vcf"
 			CMD
-				vcfix.pl -i - > "$o.fixed.nomulti.vcf"
+				vcfix.pl -i - > "$t.fixed.nomulti.vcf"
 			CMD
 
 			if [[ $dbsnp ]]; then
 				commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD {COMMANDER[3]}<<- CMD {COMMANDER[4]}<<- CMD
-					vcffixup "$o.fixed.nomulti.vcf"
+					vcffixup "$t.fixed.nomulti.vcf"
 				CMD
 					vt normalize -q -n -r "$genome" -
 				CMD
 					vcfixuniq.pl
 				CMD
-					tee -i "$o.fixed.nomulti.normed.vcf"
+					tee -i "$t.fixed.nomulti.normed.vcf"
 				CMD
-					vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$o.fixed.nomulti.normed.nodbsnp.vcf"
+					vcftools --vcf - --exclude-positions "$dbsnp" --recode --recode-INFO-all --stdout > "$t.fixed.nomulti.normed.nodbsnp.vcf"
 				CMD
 			else
 				commander::makecmd -a cmd5 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
-					vcffixup "$o.fixed.nomulti.vcf"
+					vcffixup "$t.fixed.nomulti.vcf"
 				CMD
 					vt normalize -q -n -r "$genome" -
 				CMD
-					vcfixuniq.pl > "$o.fixed.nomulti.normed.vcf"
+					vcfixuniq.pl > "$t.fixed.nomulti.normed.vcf"
 				CMD
 			fi
 
 			for e in vcf fixed.vcf fixed.nomulti.vcf fixed.nomulti.normed.vcf $([[ $dbsnp ]] && echo fixed.nomulti.normed.nodbsnp.vcf); do
-				commander::makecmd -a cmd6 -s ';' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD
-					bgzip -k -c -@ $ithreads "$o.$e" > "$o.$e.gz"
+				commander::makecmd -a cmd6 -s '|' -c {COMMANDER[0]}<<- CMD {COMMANDER[1]}<<- CMD {COMMANDER[2]}<<- CMD
+					bgzip -k -c -@ $ithreads "$t.$e"
 				CMD
-					tabix -f -p vcf "$o.$e.gz"
+					tee -i "$o.$e.gz"
+				CMD
+					bcftools index --threads $ithreads -f -t -o "$o.$e.gz.tbi"
 				CMD
 			done
 		done

--- a/lib/version.sh
+++ b/lib/version.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 # (c) Konstantin Riege
 
-version=1.4.0
+version=1.5.0

--- a/scripts/canonicals.pl
+++ b/scripts/canonicals.pl
@@ -44,9 +44,9 @@ while(<F>){
 	$l[-1]=~/transcript_id\s+(\S+)/;
 	my $t = $1 ? $1 : 'transcript';
 	$t=~s/("|;)//g;
-	if ($l[-1]=~/tag\s+\"CCDS\"/) {
+	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
-	} elsif ($l[2] eq 'ensembl_havana') {
+	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {
 		$m{$g}{2}{$t} += $l[4]-$l[3]+1;
 	} else{
 		$m{$g}{3}{$t} += $l[4]-$l[3]+1;

--- a/scripts/canonicals.pl
+++ b/scripts/canonicals.pl
@@ -21,9 +21,9 @@ use feature ":5.10";
 use List::Util qw(min max);
 
 if ($#ARGV < 2){
-	say "usage: canonicals.pl file.gtf feature-level feature-tag";
-	say "gtf needs to contain feature level e.g. exon";
-	say "and feature id tag e.g. gene_id with transcript_id";
+	say "usage: canonicals.pl <gtf> <feature-level> <feature-tag>";
+	say 'extracts canonical transcripts searching for flags CCDS/*canonical, fallbacks to the longest meta-feature composed of sub-transcript features given the associated <feature-level> e.g. "exon"';
+	say 'for each canonical transcript, the given parental <feature-tag> of interest e.g. "gene_id" or "gene_name" and the associated "transcript_id" tag is reported';
 	exit 1;
 }
 
@@ -42,8 +42,7 @@ while(<F>){
 	$g=~s/("|;)//g;
 	push @ids,$g unless exists $m{$g};
 	$l[-1]=~/transcript_id\s+(\S+)/;
-	my $t = $1 ? $1 : 'transcript';
-	$t=~s/("|;)//g;
+	my $t = $1 ? $1=~s/("|;)//gr : 'transcript';
 	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
 	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {
@@ -63,7 +62,8 @@ for my $g (keys %m){
 		push @ts,$t;
 	}
 	my $max = max(@ls);
-	say $g."\t".$ts[(grep {$ls[$_]==$max} 0..$#ls)[0]];
+	# ensures reproducibility if multiple transcripts of same length do exist
+	say $g."\t".(sort {$a cmp $b} @ts[grep {$ls[$_]==$max} 0..$#ls])[0];
 }
 
 exit 0;

--- a/scripts/dlgenome.sh
+++ b/scripts/dlgenome.sh
@@ -36,7 +36,7 @@ usage(){
 		                          : NOTE: for mouse data, genes will be substituted by Ensembl orthologs if possible
 
 		(the following options require bcftools, bgzip, tabix in PATH)
-		-s | --dbsnp              : download Ensembl common dbSNP (hg), EVA validated SNPs (mm) respectively
+		-s | --dbsnp              : download Ensembl common dbSNP (hg), EVA validated SNPs (mm) respectively (mm10 only)
 		                          : NOTE: for hg, each orignal entry is listed in 1000Genomes and contain its african, american, european, asian population MAF
 		                            -> filtered for max(MAF)>0.01
 		-n | --ncbi               : switch to NCBI common dbSNP (hg), validated SNPs (mm) respectively (mm10 only)
@@ -979,7 +979,7 @@ function dlgenome::hg19.dbsnp.ucsc() {
 	cd "$outdir"
 	genome=GRCh37
 
-	echo ":INFO: ucsc dbsnp not supported"
+	echo ":INFO: UCSC dbSNP not supported"
 	# https://groups.google.com/a/soe.ucsc.edu/g/genome-announce/c/40coV6ZVtFY
 	# https://genome.ucsc.edu/cgi-bin/hgTrackUi?db=hg19&g=dbSnp155Composite
 	# http://hgdownload.soe.ucsc.edu/gbdb/hg19/snp/dbSnp155Common.bb
@@ -1127,7 +1127,7 @@ function dlgenome::hg38.dbsnp.ucsc() {
 	cd "$outdir"
 	genome=GRCh38
 
-	echo ":INFO: ucsc dbsnp not supported"
+	echo ":INFO: UCSC dbSNP not supported"
 	return 0
 
 	# TODO needs more effort due to missing start position ref. see also
@@ -1180,7 +1180,7 @@ function dlgenome::mm10.dbsnp.gatk() {
 	cd "$outdir"
 	genome=GRCm38
 
-	echo ":INFO: gatk bundle not available"
+	echo ":INFO: GATK bundle not available"
 	return 0
 }
 
@@ -1223,8 +1223,9 @@ function dlgenome::mm10.dbsnp.ensembl() {
 	cd "$outdir"
 	genome=GRCm38
 
-	echo ":INFO: ensembl dbsnp not supported"
+	echo ":INFO: Ensembl dbSNP not supported"
 	return 0
+
 	url="https://ftp.ensembl.org/pub/release-102/variation/vcf/mus_musculus/mus_musculus.vcf.gz"
 	# contains 80M variants without any INFO on how to filter them
 }
@@ -1258,7 +1259,7 @@ function dlgenome::mm10.dbsnp.eva() {
 	cat <<- EOF >> "$genome.fa.vcf.README"
 		$(date)
 		$USER
-		EVA v"$(echo "$version" | cut -d _ -f 2 -)" $genome
+		EVA v$(echo "$version" | cut -d _ -f 2 -) $genome
 		filtered for RS_VALIDATED
 		$url
 	EOF
@@ -1279,6 +1280,7 @@ function dlgenome::mm10.dbsnp.ucsc() {
 
 	# url="https://ftp.ncbi.nih.gov/snp/organisms/archive/mouse_10090/VCF/00-All.vcf.gz"
 	# better use https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/GRCm38.p4/10090_GCA_000001635.6_current_ids.vcf.gz
+	# alternative: https://hgdownload.soe.ucsc.edu/gbdb/mm10/bbi/evaSnp6.bb
 	# filter by UCSC common
 	# 81432271 -> 8404784 VLD using NCBI
 	# 82691010 -> 8592575 RS_VALIDATED using EVA
@@ -1314,7 +1316,7 @@ function dlgenome::mm11.dbsnp.gatk() {
 	cd "$outdir"
 	genome=GRCm39
 
-	echo ":INFO: gatk bundle not available"
+	echo ":INFO: GATK bundle not available"
 	return 0
 }
 
@@ -1323,7 +1325,7 @@ function dlgenome::mm11.dbsnp.ncbi() {
 	cd "$outdir"
 	genome=GRCm39
 
-	echo ":INFO: ncbi dbsnp not available"
+	echo ":INFO: NCBI dbSNP not available"
 	return 0
 }
 
@@ -1332,7 +1334,7 @@ function dlgenome::mm11.dbsnp.ensembl() {
 	cd "$outdir"
 	genome=GRCm39
 
-	echo ":INFO: ensembl dbsnp not supported"
+	echo ":INFO: Ensembl dbSNP not supported"
 	return 0
 
 	url="https://ftp.ensembl.org/pub/"
@@ -1344,6 +1346,11 @@ alias dlgenome::mm11.dbsnp.eva="_bashbone_wrapper dlgenome::mm11.dbsnp.eva"
 function dlgenome::mm11.dbsnp.eva() {
 	cd "$outdir"
 	genome=GRCm39
+
+	echo ":INFO: eva dbsnp not supported"
+	return 0
+	# in contrast to mm10, likewise to ncbi, the vcf file has no validation info included
+
 	echo ":INFO: downloading dbSNP"
 
 	url="https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/"
@@ -1364,7 +1371,7 @@ function dlgenome::mm11.dbsnp.eva() {
 	cat <<- EOF >> "$genome.fa.vcf.README"
 		$(date)
 		$USER
-		EVA v"$(echo "$version" | cut -d _ -f 2-)" $genome
+		EVA v$(echo "$version" | cut -d _ -f 2-) $genome
 		$url
 		filtered for RS_VALIDATED
 	EOF
@@ -1375,7 +1382,7 @@ function dlgenome::mm11.dbsnp.ucsc() {
 	cd "$outdir"
 	genome=GRCm39
 
-	echo ":INFO: ucsc dbsnp not supported"
+	echo ":INFO: UCSC dbSNP not supported"
 	return 0
 	# bigBedToBed https://hgdownload.soe.ucsc.edu/gbdb/mm39/bbi/evaSnp6.bb
 	# ucsc data source is eva

--- a/scripts/dlgenome.sh
+++ b/scripts/dlgenome.sh
@@ -1,245 +1,262 @@
 #! /usr/bin/env bash
 # (c) Konstantin Riege
 
-source "$(dirname "$0")/../bashbone_lite.sh" -x cleanup -a "$@" || exit 1
+source "$(dirname "$0")/../bashbone_lite.sh" -a "$@" || exit 1
 
 ############################################
-
-cleanup(){
-	[[ $outdir ]] && rm -rf "$outdir/tmp"
-	return 0
-}
 
 usage(){
 	cat <<- EOF
 		DESCRIPTION
-		$(basename $0) downloads most recent human or mouse genome and annotation including gene ontology plus orthologs and optionally dbSNP
+		$(basename $0) downloads most recent human or mouse genome, annotation, gene ontology, orthologs, dbSNP
 
 		VERSION
-		0.7.0
+		1.0.0
 
 		SYNOPSIS
-		$(basename $0) -r [hg19|hg38|mm10] -g -a -d -s -n
+		$(basename $0) -r [hg19|hg38|mm10|mm11] -o <PATH> -t <THREADS> [-g|-c] [-a] [-d|-m|-e] [-s|-n|-u|-k]
 
 		INPUT OPTIONS
 		-h | --help               : prints this message
 		-t | --threads [value]    : threads - predicted default: $threads
 		-o | --out [path]         : output directory - default: $PWD
-		-r | --reference [string] : choose hg19 hg38 mm10 mm11
+		-r | --reference [string] : choose one of hg19 hg38 mm10 mm11
+
+		(the following options require bgzip in PATH)
 		-g | --genome             : download Ensembl genome
 		-c | --ctat               : switch to CTAT genome and indices (~30GB)
+
+		(the following options require bgzip and optional tabix in PATH)
 		-a | --annotation         : download Ensembl gtf
-		-d | --descriptions       : download Ensembl gene description and Ensembl ontology information (requires R in PATH)
-		-m | --msigdb             : download Ensembl gene description, MSigDB gene ontology information and other collections (requires R in PATH)
-		-e | --enrichr            : download Ensembl gene description and Enrichr gene ontology and other collections (requires R in PATH)
+
+		(the following options require R in PATH)
+		-d | --descriptions       : download Ensembl gene description and Ensembl ontology information
+		-m | --msigdb             : switch to MSigDB gene ontology information and other collections (recommended since Ensembl has too many and incomplete sets)
+		-e | --enrichr            : switch to Enrichr gene ontology and other collections
 		                          : NOTE: for mouse data, genes will be substituted by Ensembl orthologs if possible
-		-s | --dbsnp              : download Ensembl dbSNP
-		-n | --ncbi               : switch to NCBI dbSNP
+
+		(the following options require bcftools, bgzip, tabix in PATH)
+		-s | --dbsnp              : download Ensembl common dbSNP (hg), EVA validated SNPs (mm) respectively
+		                          : NOTE: for hg, each orignal entry is listed in 1000Genomes and contain its african, american, european, asian population MAF
+		                            -> filtered for max(MAF)>0.01
+		-n | --ncbi               : switch to NCBI common dbSNP (hg), validated SNPs (mm) respectively (mm10 only)
+		                          : NOTE: for hg, an original entry may be listed in 1000Genomes. tagged as common if representative major project MAF>0.01
+		                            -> filtered for COMMON and 1000Genomes
+		-u | --ucsc               : switch to UCSC common dbSNP v142 (mm10 only)
+		                          : NOTE: each entry is listed in 1000Genomes and is common due to a representative major project MAF>0.01
+		                           -> although UCSC uses NCBI sources, selection of variants slightly differs
+		-k | --gatk               : switch to GATK SNP bundle (hg only)
 
 		REFERENCES
 		(c) Konstantin Riege
 		konstantin.riege{a}leibniz-fli{.}de
 	EOF
+
 	return 1
 }
 
-######
-# go #
-######
+################################################################################
+# GO
+################################################################################
 
-dlgenome::_go.ensembl(){
+alias dlgenome::_go.ensembl="_bashbone_wrapper dlgenome::_go.ensembl"
+function dlgenome::_go.ensembl(){
 	out="$outdir/$genome.fa.gtf"
 
-	export R_LIBS="$outdir/tmp"
+	tdir="$(mktemp -d -p "${TMPDIR:-/tmp}" XXXXXXXXXX.rlibs)"
+	export R_LIBS="$tdir"
 	mkdir -p "$R_LIBS"
 	# listDatasets(useEnsembl(biomart = "genes"))
 	# listDatasets(useEnsembl(biomart = "ensembl"))
 
 	[[ $(R --version | head -1 | awk '$3<3.5{print 1}') ]] && {
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("biocLite", quietly = TRUE)) source("https://bioconductor.org/biocLite.R")
 				biocLite("biomaRt", suppressUpdates=TRUE)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			goids <- data.frame()
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				goids <- rbind(goids, getBM(mart=ensembl, attributes=c("ensembl_gene_id","go_id","namespace_1003","name_1006"), filters=c("chromosome_name"), values=list(chr)))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(goids,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.go")
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
-
-			sink("$out.go.README")
-			cat("$(date)\n")
-			cat("$USER\n")
-			cat(paste0("Ensembl go v",v,"\n")))
-			cat("via biomart\n")
-			sink()
 		EOF
 	} || {
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos="http://cloud.r-project.org", Ncpus=$threads, clean=T)
 				library("BiocManager")
 				BiocManager::install(c("biomaRt"), Ncpus=$threads, clean=T)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			goids <- data.frame()
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				goids <- rbind(goids, getBM(mart=ensembl, attributes=c("ensembl_gene_id","go_id","namespace_1003","name_1006"), filters=c("chromosome_name"), values=list(chr)))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(goids,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.go")
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
-
-			sink("$out.go.README")
-			cat("$(date)\n")
-			cat("$USER\n")
-			cat(paste0("Ensembl go v",v,"\n"))
-			cat("via biomart\n")
-			sink()
 		EOF
 	}
+	cat <<- EOF >> "$tdir/download.R"
+		library("biomaRt")
+		v <- "$version"
+		for (try in 1;10){
+			tryCatch({
+				if ("$version" == "latest"){
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
+					v <- listEnsemblArchives()\$version[2]
+				} else {
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
+				}
+				try <- 0
+				break
+			}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+		}
+		if(try!=0) quit("no",1)
+		cat(paste0(":INFO: v",v," from Ensembl\n"))
+
+		goids <- data.frame()
+		descriptions <- data.frame()
+		for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
+			cat(paste0(":INFO: working on chr",chr,"\n"))
+			df <- data.frame()
+			for (try in 1:10){
+				tryCatch({
+					df <- getBM(mart=ensembl, attributes=c("ensembl_gene_id","go_id","namespace_1003","name_1006"), filters=c("chromosome_name"), values=list(chr))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+			}
+			if(try!=0) quit("no",1)
+			goids <- rbind(goids, df)
+			df <- data.frame()
+			for (try in 1:10){
+				tryCatch({
+					df <- getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+			}
+			if(try!=0) quit("no",1)
+			descriptions <- rbind(descriptions, df)
+		}
+		descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
+		write.table(goids,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.go")
+		write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
+
+		orthos <- data.frame()
+		for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
+			cat(paste0(":INFO: working on orthologs from Ensembl v",v,"\n"))
+			for (try in 1:2){
+				tryCatch({
+					ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
+					ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
+					orthos <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 2"))})
+			}
+			if(try==0) break
+		}
+		if(try!=0) quit("no",1)
+		write.table(orthos,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
+
+		sink("$out.go.README")
+		cat("$(date)\n")
+		cat("$USER\n")
+		cat(paste0("Ensembl go v",v,"\n"))
+		cat("via biomart\n")
+		sink()
+	EOF
 
 	echo ":INFO: downloading gene ontology and descriptions"
-	Rscript "$outdir/tmp/download.R"
+	Rscript "$tdir/download.R"
 
-	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" > "$out.orthologs.unique"
-	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" >> "$out.orthologs.unique"
+	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" > "$out.orthologs.unique"
+	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" >> "$out.orthologs.unique"
 
 	return 0
 }
 
-dlgenome::_go.enrichr(){
+alias dlgenome::_go.enrichr="_bashbone_wrapper dlgenome::_go.enrichr"
+function dlgenome::_go.enrichr(){
 	out="$outdir/$genome.fa.gtf"
 
-	export R_LIBS="$outdir/tmp"
+	tdir="$(mktemp -d -p "${TMPDIR:-/tmp}" XXXXXXXXXX.rlibs)"
+	export R_LIBS="$tdir"
 	mkdir -p "$R_LIBS"
 
 	[[ $(R --version | head -1 | awk '$3<3.5{print 1}') ]] && {
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("biocLite", quietly = TRUE)) source("https://bioconductor.org/biocLite.R")
 				biocLite("biomaRt", suppressUpdates=TRUE)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
 		EOF
 	} || {
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos="http://cloud.r-project.org", Ncpus=$threads, clean=T)
 				library("BiocManager")
 				BiocManager::install(c("biomaRt"), Ncpus=$threads, clean=T)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
 		EOF
 	}
+	cat <<- EOF >> "$tdir/download.R"
+		library("biomaRt")
+		v <- "$version"
+		for (try in 1:10){
+			tryCatch({
+				if ("$version" == "latest"){
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
+					v <- listEnsemblArchives()\$version[2]
+				} else {
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
+				}
+				try <- 0
+				break
+			}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+		}
+		if(try!=0) quit("no",1)
+		cat(paste0(":INFO: v",v," from Ensembl\n"))
+
+		descriptions <- data.frame()
+		for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
+			cat(paste0(":INFO: working on chr",chr,"\n"))
+			df <- data.frame()
+			for (try in 1:10){
+				tryCatch({
+					df <- getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+			}
+			if(try!=0) quit("no",1)
+			descriptions <- rbind(descriptions, df)
+		}
+		descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
+		write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
+
+		orthos <- data.frame()
+		for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
+			cat(paste0(":INFO: working on orthologs from Ensembl v",v,"\n"))
+			for (try in 1:2){
+				tryCatch({
+					ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
+					ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
+					orthos <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 2"))})
+			}
+			if(try==0) break
+		}
+		if(try!=0) quit("no",1)
+		write.table(orthos,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
+	EOF
 
 	echo ":INFO: downloading gene ontology and descriptions"
-	Rscript "$outdir/tmp/download.R"
+	Rscript "$tdir/download.R"
 
-	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" > "$out.orthologs.unique"
-	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" >> "$out.orthologs.unique"
+	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" > "$out.orthologs.unique"
+	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" >> "$out.orthologs.unique"
 
-	wget -O "$outdir/tmp/ncbi.info.gz" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
-	gzip -dc "$outdir/tmp/ncbi.info.gz" | perl -lanE 'next unless $F[5]=~/Ensembl:(ENSG\d+)/; say "$F[2]\t$1"' > "$outdir/tmp/ncbi.info"
+	# wget -O "$tdir/ncbi.info.gz" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
+	# gzip -dc "$tdir/ncbi.info.gz" | perl -lanE 'next unless $F[5]=~/Ensembl:(ENSG\d+)/; say "$F[2]\t$1"' > "$tdir/ncbi.info"
+	url="https://ftp.ncbi.nlm.nih.gov/gene/DATA/GENE_INFO/Mammalia/Homo_sapiens.gene_info.gz"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kcd -@ 1 | perl -lanE 'next unless $F[5]=~/Ensembl:(ENSG\d+)/; say "$F[2]\t$1"' > "$tdir/ncbi2ensembl"
 
 	cat <<-EOF > "$out.go.README"
 		$(date)
@@ -252,9 +269,8 @@ dlgenome::_go.enrichr(){
 		version=$(date +%Y)
 		while :; do
 			url="https://maayanlab.cloud/Enrichr/geneSetLibrary?mode=text&libraryName=${collection}_$version"
-			echo loading $collection $version
 			[[ "$collection" =~ ^(WikiPathways|KEGG) ]] && url+="_$msig"
-			wget -O "$outdir/tmp/$collection.gmt" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" && break
+			wget -O "$tdir/$collection.gmt" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" && echo ":INFO: working on $collection $version" && break
 			((version--))
 		done
 		perl -F'\t' -slanE '
@@ -286,119 +302,121 @@ dlgenome::_go.enrichr(){
 				next unless $i;
 				say join"\t",($i,$n=~s/\s+/_/gr,$collection,$F[0]);
 			}
-		' -- -info="$outdir/tmp/ncbi.info" -species="$msig" -ortho="$out.orthologs.unique" -collection="$collection" "$outdir/tmp/$collection.gmt" >> "$out.go"
+		' -- -info="$tdir/ncbi2ensembl" -species="$msig" -ortho="$out.orthologs.unique" -collection="$collection" "$tdir/$collection.gmt" >> "$out.go"
 		echo "Enrichr $collection v$version" >> "$out.go.README"
 	done
 
 	return 0
 }
 
-dlgenome::_go.msigdb(){
+alias dlgenome::_go.msigdb="_bashbone_wrapper dlgenome::_go.msigdb"
+function dlgenome::_go.msigdb(){
 	out="$outdir/$genome.fa.gtf"
 
-	export R_LIBS="$outdir/tmp"
+	tdir="$(mktemp -d -p "${TMPDIR:-/tmp}" XXXXXXXXXX.rlibs)"
+	export R_LIBS="$tdir"
 	mkdir -p "$R_LIBS"
 
 	[[ $(R --version | head -1 | awk '$3<3.5{print 1}') ]] && {
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("biocLite", quietly = TRUE)) source("https://bioconductor.org/biocLite.R")
 				biocLite("biomaRt", suppressUpdates=TRUE)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
 		EOF
 	} || {
 		# does not work anymore. use default: NULL. if ("$version" == "latest") v <- NULL
-		cat <<- EOF > $outdir/tmp/download.R
+		cat <<- EOF > "$tdir/download.R"
 			if (!requireNamespace("biomaRt", quietly = TRUE)) {
 				if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager", repos="http://cloud.r-project.org", Ncpus=$threads, clean=T)
 				library("BiocManager")
 				BiocManager::install(c("biomaRt"), Ncpus=$threads, clean=T)
 			}
-			library("biomaRt")
-			v <- "$version"
-			if ("$version" == "latest"){
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
-				v <- v <- listEnsemblArchives()\$version[2]
-			} else {
-				ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
-			}
-			descriptions <- data.frame()
-			for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
-				cat(paste0("downloading datasets of chr",chr,", please wait...\n"))
-				descriptions <- rbind(descriptions, getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr)))
-			}
-			descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
-			write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
-
-			for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
-				tryCatch(
-					{	ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
-						ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
-						df <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
-						break
-					}, error = function(e){}
-				)
-			}
-			write.table(df,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
 		EOF
 	}
+	cat <<- EOF >> "$tdir/download.R"
+		library("biomaRt")
+		v <- "$version"
+		for (try in 1:10){
+			tryCatch({
+				if ("$version" == "latest"){
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset")
+					v <- listEnsemblArchives()\$version[2]
+				} else {
+					ensembl <- useEnsembl(biomart="genes", dataset="$dataset", version=v)
+				}
+			}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+			try <- 0
+			break
+		}
+		if(try!=0) quit("no",1)
+		cat(paste0(":INFO: v",v," from Ensembl\n"))
+
+		descriptions <- data.frame()
+		for (chr in grep("^(MT|X|Y|\\\d+)$",listFilterOptions(mart = ensembl, filter = "chromosome_name"), value=T, perl=T)){
+			cat(paste0(":INFO: working on chr",chr,"\n"))
+			df <- data.frame()
+			for (try in 1:10){
+				tryCatch({
+					df <- getBM(mart=ensembl, attributes=c("ensembl_gene_id","external_gene_name","gene_biotype","description"), filters=c("chromosome_name"), values=list(chr))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 10"))})
+			}
+			if(try!=0) quit("no",1)
+			descriptions <- rbind(descriptions, df)
+		}
+		descriptions[,2][descriptions[2]==""] <- descriptions[,1][descriptions[2]==""]
+		write.table(descriptions,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.info")
+
+		orthos <- data.frame()
+		for (v in as.vector(na.omit(as.integer(listEnsemblArchives()\$version)))){
+			cat(paste0(":INFO: working on orthologs from Ensembl v",v,"\n"))
+			for (try in 1:2){
+				tryCatch({
+					ensembl_Hs <- useEnsembl(biomart="genes", dataset="hsapiens_gene_ensembl", version=v)
+					ensembl_Mm <- useEnsembl(biomart="genes", dataset="mmusculus_gene_ensembl", version=v)
+					orthos <- getLDS(mart = ensembl_Hs, martL = ensembl_Mm, attributes = c("ensembl_gene_id","external_gene_name"), attributesL = c("ensembl_gene_id","external_gene_name"))
+					try <- 0
+					break
+				}, error = function(e){message(paste0(":WARNING: connection failed at try ",try," out of 2"))})
+			}
+			if(try==0) break
+		}
+		if(try!=0) quit("no",1)
+		write.table(orthos,quote=FALSE,row.names=FALSE,col.names=FALSE,sep="\t",file="$out.orthologs")
+	EOF
 
 	echo ":INFO: downloading gene ontology and descriptions"
-	Rscript "$outdir/tmp/download.R"
+	# Rscript "$tdir/download.R"
 
-	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" > "$out.orthologs.unique"
-	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$outdir/tmp/orthologs"
-	cut -f 1 "$outdir/tmp/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$outdir/tmp/orthologs" >> "$out.orthologs.unique"
+	awk -F '\t' -v OFS='\t' '$2~/\S/ && $4~/\S/ && tolower($2)==tolower($4) {print $1,$3}' "$out.orthologs" > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" > "$out.orthologs.unique"
+	cut -f 1 "$out.orthologs.unique" | grep -vFw -f - "$out.orthologs" | grep -vFw -f <(cut -f 2 "$out.orthologs.unique") | cut -f 1,3 > "$tdir/orthologs"
+	cut -f 1 "$tdir/orthologs" | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" | cut -f 2 | sort | uniq -c | awk '$1==1{print $2}' | grep -Fw -f - "$tdir/orthologs" >> "$out.orthologs.unique"
 
 	version=$(curl -s https://data.broadinstitute.org/gsea-msigdb/msigdb/release/ | grep -oE ">[0-9][^<]+($msig)" | sed 's/^>//' | sort -Vr | head -1)
 	[[ "$msig" == "Hs" ]] && msig="human" || msig="mouse"
-	wget -P "$outdir/tmp/" -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --recursive --no-directories --no-parent --level=1 --reject 'index.htm*' --accept-regex ".*\.go\.(bp|mf|cc)\.v$version.symbols.gmt" "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/$version/"
-	wget -O "$outdir/tmp/go.obo" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping http://purl.obolibrary.org/obo/go.obo
+	wget -P "$tdir/" -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --recursive --no-directories --no-parent --level=1 --reject 'index.htm*' --accept-regex ".*\.go\.(bp|mf|cc)\.v$version.symbols.gmt" "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/$version/"
+	wget -O "$tdir/go.obo" -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "http://purl.obolibrary.org/obo/go.obo"
 
-	grep -Fx '[Term]' -A 3 "$outdir/tmp/go.obo" | grep -vFx -- '--' | paste - - - - | cut -f 2- | sed -E 's/(id:|name:|namespace:)\s//g' | perl -F'\t' -lane '$F[1]=~s/#//; $F[1]=~s/^OBSOLETE\s*//i; print join"\t",@F' > "$outdir/tmp/go.terms.orig"
-	grep -Fx '[Term]' -A 3 "$outdir/tmp/go.obo" | grep -vFx -- '--' | paste - - - - | cut -f 2- | sed -E 's/(id:|name:|namespace:)\s//g' | perl -F'\t' -lane '$F[1]=uc($F[1]=~s/\W+/_/gr); $F[1]=~s/^_+//; $F[1]=~s/_+$//; $F[1]=~s/_+/_/g; $F[1]=~s/^OBSOLETE_//; print join"\t",@F' > "$outdir/tmp/go.terms"
+	grep -Fx '[Term]' -A 3 "$tdir/go.obo" | grep -vFx -- '--' | paste - - - - | cut -f 2- | sed -E 's/(id:|name:|namespace:)\s//g' | perl -F'\t' -lane '$F[1]=~s/#//; $F[1]=~s/^OBSOLETE\s*//i; print join"\t",@F' > "$tdir/go.terms.orig"
+	grep -Fx '[Term]' -A 3 "$tdir/go.obo" | grep -vFx -- '--' | paste - - - - | cut -f 2- | sed -E 's/(id:|name:|namespace:)\s//g' | perl -F'\t' -lane '$F[1]=uc($F[1]=~s/\W+/_/gr); $F[1]=~s/^_+//; $F[1]=~s/_+$//; $F[1]=~s/_+/_/g; $F[1]=~s/^OBSOLETE_//; print join"\t",@F' > "$tdir/go.terms"
 
 	rm -f "$out.go"
-	for gmt in "$outdir/tmp/"*.v$version.symbols.gmt; do
-		cut -f 1 "$gmt" | sed -E 's/^GO.._//' > "$outdir/tmp/gmt.terms"
-		grep -Fw -f "$outdir/tmp/gmt.terms" "$outdir/tmp/go.terms" > "$outdir/tmp/gmt.terms.parsed"
-		grep -vFx -f <(cut -f 2 "$outdir/tmp/gmt.terms.parsed") "$outdir/tmp/gmt.terms" > "$outdir/tmp/gmt.terms.missing"
-		c=$(cut -d . -f 3 <<< "$gmt" | perl -lane 'print "GO".uc($_)')
-		x=$(wc -l < "$outdir/tmp/gmt.terms.missing")
+	for gmt in "$tdir/"*.v$version.symbols.gmt; do
+		cut -f 1 "$gmt" | sed -E 's/^GO.._//' > "$tdir/gmt.terms"
+		grep -Fw -f "$tdir/gmt.terms" "$tdir/go.terms" > "$tdir/gmt.terms.parsed"
+		grep -vFx -f <(cut -f 2 "$tdir/gmt.terms.parsed") "$tdir/gmt.terms" > "$tdir/gmt.terms.missing"
+		c=$(basename "$gmt" | cut -d . -f 3 | perl -lane 'print "GO".uc($_)')
+		x=$(wc -l < "$tdir/gmt.terms.missing")
 		i=0
 		while read -r n; do
 			echo "requesting $((++i)) of $x missing $c terms" >&2
 			g=$(curl -s "https://www.gsea-msigdb.org/gsea/msigdb/$msig/geneset/${c}_$n" | grep -oP 'GO:\d+</td>' | cut -d '<' -f 1 | sort -u)
 			[[ $g ]] || echo ":WARNING: no term found for $n"
-			grep -m 1 -Fw $g "$outdir/tmp/go.terms" | awk -F '\t' -v n=$n -v OFS='\t' '{print $1,n,$3}' >> "$outdir/tmp/gmt.terms.parsed"
-		done < "$outdir/tmp/gmt.terms.missing"
+			grep -m 1 -Fw $g "$tdir/go.terms" | awk -F '\t' -v n=$n -v OFS='\t' '{print $1,n,$3}' >> "$tdir/gmt.terms.parsed"
+		done < "$tdir/gmt.terms.missing"
 		perl -F'\t' -slanE '
 			BEGIN{
 				open F,"<$terms" or die $!;
@@ -431,7 +449,7 @@ dlgenome::_go.msigdb(){
 				next unless $i;
 				say $i."\t".$x;
 			}
-		' -- -terms="$outdir/tmp/gmt.terms.parsed" -go="$outdir/tmp/go.terms.orig" -info="$out.info" "$gmt" >> "$out.go"
+		' -- -terms="$tdir/gmt.terms.parsed" -go="$tdir/go.terms.orig" -info="$out.info" "$gmt" >> "$out.go"
 	done
 
 	while read -r collection gmt; do
@@ -463,17 +481,8 @@ dlgenome::_go.msigdb(){
 	return 0
 }
 
-dlgenome::hg38.go(){
-	cd "$outdir"
-	genome=GRCh38
-	dataset="hsapiens_gene_ensembl"
-	version="latest"
-	msig=Hs
-	dlgenome::_go.$godb
-	return 0
-}
-
-dlgenome::hg19.go(){
+alias dlgenome::hg19.go="_bashbone_wrapper dlgenome::hg19.go"
+function dlgenome::hg19.go(){
 	cd "$outdir"
 	genome=GRCh37
 	dataset="hsapiens_gene_ensembl"
@@ -483,7 +492,19 @@ dlgenome::hg19.go(){
 	return 0
 }
 
-dlgenome::mm10.go(){
+alias dlgenome::hg38.go="_bashbone_wrapper dlgenome::hg38.go"
+function dlgenome::hg38.go(){
+	cd "$outdir"
+	genome=GRCh38
+	dataset="hsapiens_gene_ensembl"
+	version="latest"
+	msig=Hs
+	dlgenome::_go.$godb
+	return 0
+}
+
+alias dlgenome::mm10.go="_bashbone_wrapper dlgenome::mm10.go"
+function dlgenome::mm10.go(){
 	cd "$outdir"
 	genome=GRCm38
 	dataset="mmusculus_gene_ensembl"
@@ -493,7 +514,8 @@ dlgenome::mm10.go(){
 	return 0
 }
 
-dlgenome::mm11.go(){
+alias dlgenome::mm11.go="_bashbone_wrapper dlgenome::mm11.go"
+function dlgenome::mm11.go(){
 	cd "$outdir"
 	genome=GRCm39
 	dataset="mmusculus_gene_ensembl"
@@ -503,559 +525,970 @@ dlgenome::mm11.go(){
 	return 0
 }
 
-##########
-#  hg38  #
-##########
+################################################################################
+#  GENOME
+################################################################################
 
-dlgenome::hg38.genome() {
+alias ddlgenome::hg19.genome="_bashbone_wrapper dlgenome::hg19.genome"
+function dlgenome::hg19.genome() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading $genome genome"
+	url="https://ftp.ensembl.org/pub/grch37/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome"
+	version=$(grep -oE 'release-[0-9]+' <<< "$url" | cut -d '-' -f 2-)
+	echo ":INFO: v$version from Ensembl"
+
+	rm -f "$genome.fa"
+	for i in MT {1..22} X Y; do
+		echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i)
+		wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url.$i.fa.gz" | bgzip -kcd -@ 1  | sed "s/^>MT.*/>chrM/;t;s/^>.*/>chr$i/" >> "$genome.fa"
+	done
+
+
+	cat <<- EOF > "$genome.fa.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$(dirname "$url")
+	EOF
+
+	return 0
+}
+
+alias dlgenome::hg38.genome="_bashbone_wrapper dlgenome::hg38.genome"
+function dlgenome::hg38.genome() {
 	cd "$outdir"
 	genome=GRCh38
 
 	echo ":INFO: downloading $genome genome"
-	wget -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.chromosome.*.fa.gz'
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.chromosome"
+	version=$(grep -oE 'release-[0-9]+' <<< "$url" | cut -d '-' -f 2-)
+	echo ":INFO: v$version from Ensembl"
 
-	echo ":INFO: extracting genome"
-	gzip -dc Homo_sapiens.GRCh38.dna.chromosome.MT.fa.gz | sed "s/>.*/>chrM/" > $genome.fa
-	for i in {1..22} X Y; do
-		gzip -dc Homo_sapiens.GRCh38.dna.chromosome.$i.fa.gz | sed "s/>.*/>chr$i/" >> $genome.fa
+	rm -f "$genome.fa"
+	for i in MT {1..22} X Y; do
+		echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i)
+		wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url.$i.fa.gz" | bgzip -kcd -@ 1 | sed "s/^>MT.*/>chrM/;t;s/^>.*/>chr$i/" >> "$genome.fa"
 	done
 
-	ensembl=$(ls -v Homo_sapiens.GRCh38.dna.chromosome.*.fa.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.README
+	cat <<- EOF > "$genome.fa.README"
 		$(date)
 		$USER
-		Ensembl $genome genome
-		ftp://ftp.ensembl.org/pub/current_fasta/fasta/homo_sapiens/dna/
+		Ensembl v$version $genome
+		$(dirname "$url")
 	EOF
 
-	rm -f Homo_sapiens.GRCh38.dna.chromosome.*.fa.gz
 	return 0
 }
 
-dlgenome::hg38.gtf() {
+alias dlgenome::mm10.genome="_bashbone_wrapper dlgenome::mm10.genome"
+function dlgenome::mm10.genome() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: downloading $genome genome"
+	url="https://ftp.ensembl.org/pub/release-102/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.chromosome"
+	version=$(grep -oE 'release-[0-9]+' <<< "$url" | cut -d '-' -f 2-)
+	echo ":INFO: v$version from Ensembl"
+
+	rm -f "$genome.fa"
+	for i in MT {1..19} X Y; do
+		echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i)
+		wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url.$i.fa.gz" | bgzip -kcd -@ 1 | sed "s/^>MT.*/>chrM/;t;s/^>.*/>chr$i/" >> "$genome.fa"
+	done
+
+	cat <<- EOF > "$genome.fa.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$(dirname "$url")
+	EOF
+
+	return 0
+}
+
+alias dlgenome::mm11.genome="_bashbone_wrapper dlgenome::mm11.genome"
+function dlgenome::mm11.genome() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: downloading $genome genome"
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/fasta/mus_musculus/dna/Mus_musculus.GRCm39.dna.chromosome"
+	version=$(grep -oE 'release-[0-9]+' <<< "$url" | cut -d '-' -f 2-)
+	echo ":INFO: v$version from Ensembl"
+
+	rm -f "$genome.fa"
+	for i in MT {1..19} X Y; do
+		echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i)
+		wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url.$i.fa.gz" | bgzip -kcd -@ 1 | sed "s/^>MT.*/>chrM/;t;s/^>.*/>chr$i/" >> "$genome.fa"
+	done
+
+	cat <<- EOF > "$genome.fa.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$(dirname "$url")
+	EOF
+
+	return 0
+}
+
+################################################################################
+# GTF
+################################################################################
+
+alias dlgenome::hg19.gtf="_bashbone_wrapper dlgenome::hg19.gtf"
+function dlgenome::hg19.gtf() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading annotation"
+	url="https://ftp.ensembl.org/pub/grch37/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/gtf/homo_sapiens/"
+	url+="$(curl -s "$url" | grep -oE 'Homo_sapiens.GRCh37.[0-9]+.chr.gtf.gz' | sort -Vr | head -1)"
+	version="$(basename "$url" | cut -d . -f 3)"
+	echo ":INFO: v$version from Ensembl"
+
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" \
+		| bgzip -kcd -@ 1 \
+		| sed -n '/^#/!{s/^MT/chrM/p;t;s/^/chr/p}' \
+		| LC_ALL=C sort -S 4096M -T "${TMPDIR:-/tmp}" --parallel=$threads -k1,1 -k4,4n -k5,5n \
+		| perl -e 'while(<STDIN>){@F=split; push $m{$F[0]}->@*,$_} print $m{$_}->@* for @ARGV' chrM chr{1..22} chrX chrY \
+		| tee >(bgzip -kc -@ $threads > "$genome.fa.gtf.gz") > "$genome.fa.gtf" | cat
+	[[ -x "$(command -v tabix)" ]] && tabix -f "$genome.fa.gtf.gz"
+
+	cat <<- EOF > "$genome.fa.gtf.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::hg38.gtf="_bashbone_wrapper dlgenome::hg38.gtf"
+function dlgenome::hg38.gtf() {
 	cd "$outdir"
 	genome=GRCh38
 
 	echo ":INFO: downloading annotation"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_gtf/homo_sapiens/Homo_sapiens.GRCh38.*.chr.gtf.gz'
 
-	echo ":INFO: extracting annotation"
-	gzip -dc Homo_sapiens.GRCh38.*.chr.gtf.gz | perl -F'\t' -lane 'next unless $F[0]=~/^(\d+|X|Y|MT)$/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.gtf";} print O join("\t",@F); END{close O};'
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/gtf/homo_sapiens/"
+	url+="$(curl -s "$url" | grep -oE 'Homo_sapiens.GRCh38.[0-9]+.chr.gtf.gz' | sort -Vr | head -1)"
+	version="$(basename "$url" | cut -d . -f 3)"
+	echo ":INFO: v$version from Ensembl"
 
-	echo ":INFO: sorting annotation"
-	rm -f $genome.fa.gtf
-	for i in M {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k4,4n -k5,5n chr$i.gtf >> $genome.fa.gtf
-	done
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" \
+		| bgzip -kcd -@ 1 \
+		| sed -n '/^#/!{s/^MT/chrM/p;t;s/^/chr/p}' \
+		| LC_ALL=C sort -S 4096M -T "${TMPDIR:-/tmp}" --parallel=$threads -k1,1 -k4,4n -k5,5n \
+		| perl -e 'while(<STDIN>){@F=split; push $m{$F[0]}->@*,$_} print $m{$_}->@* for @ARGV' chrM chr{1..22} chrX chrY \
+		| tee >(bgzip -kc -@ $threads > "$genome.fa.gtf.gz") > "$genome.fa.gtf" | cat
+	[[ -x "$(command -v tabix)" ]] && tabix -f "$genome.fa.gtf.gz"
 
-	ensembl=$(ls -v Homo_sapiens.GRCh38.*.chr.gtf.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.gtf.README
+	cat <<- EOF > "$genome.fa.gtf.README"
 		$(date)
 		$USER
-		Ensembl $genome gtf v$ensembl
-		ftp://ftp.ensembl.org/pub/current_gtf/homo_sapiens/
+		Ensembl v$version $genome
+		$url
 	EOF
 
-	rm -f Homo_sapiens.GRCh38.*.chr.gtf.gz
-	rm -f chr*.gtf
 	return 0
 }
 
-dlgenome::hg38.dbsnp.ensembl() {
+alias dlgenome::mm10.gtf="_bashbone_wrapper dlgenome::mm10.gtf"
+function dlgenome::mm10.gtf() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: downloading annotation"
+	# wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/release-102/gtf/mus_musculus/Mus_musculus.GRCm38.*.chr.gtf.gz'
+
+	# echo ":INFO: extracting annotation"
+	# gzip -dc Mus_musculus.GRCm38.*.chr.gtf.gz | perl -F'\t' -lane 'next unless $F[0]=~/^(\d+|X|Y|MT)$/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.gtf";} print O join("\t",@F); END{close O};'
+
+	# echo ":INFO: sorting annotation"
+	# rm -f $genome.fa.gtf
+	# for i in M {1..19} X Y; do
+	# 	LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k4,4n -k5,5n chr$i.gtf >> $genome.fa.gtf
+	# done
+
+	url="https://ftp.ensembl.org/pub/release-102/gtf/mus_musculus/"
+	url+=$(curl -s "$url" | grep -oE 'Mus_musculus.GRCm38.[0-9]+.chr.gtf.gz' | sort -Vr | head -1)
+	version="$(basename "$url" | cut -d . -f 3)"
+	echo ":INFO: v$version from Ensembl"
+
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" \
+		| bgzip -kcd -@ 1 \
+		| sed -n '/^#/!{s/^MT/chrM/p;t;s/^/chr/p}' \
+		| LC_ALL=C sort -S 4096M -T "${TMPDIR:-/tmp}" --parallel=$threads -k1,1 -k4,4n -k5,5n \
+		| perl -e 'while(<STDIN>){@F=split; push $m{$F[0]}->@*,$_} print $m{$_}->@* for @ARGV' chrM chr{1..19} chrX chrY \
+		| tee >(bgzip -kc -@ $threads > "$genome.fa.gtf.gz") > "$genome.fa.gtf" | cat
+	[[ -x "$(command -v tabix)" ]] && tabix -f "$genome.fa.gtf.gz"
+
+	cat <<- EOF > "$genome.fa.gtf.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::mm11.gtf="_bashbone_wrapper dlgenome::mm11.gtf"
+function dlgenome::mm11.gtf() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: downloading annotation"
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/gtf/mus_musculus/"
+	url+="$(curl -s "$url" | grep -oE 'Mus_musculus.GRCm39.[0-9]+.chr.gtf.gz' | sort -Vr | head -1)"
+	version="$(basename "$url" | cut -d . -f 3)"
+	echo ":INFO: v$version from Ensembl"
+
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" \
+		| bgzip -kcd -@ 1 \
+		| sed -n '/^#/!{s/^MT/chrM/p;t;s/^/chr/p}' \
+		| LC_ALL=C sort -S 4096M -T "${TMPDIR:-/tmp}" --parallel=$threads -k1,1 -k4,4n -k5,5n \
+		| perl -e 'while(<STDIN>){@F=split; push $m{$F[0]}->@*,$_} print $m{$_}->@* for @ARGV' chrM chr{1..19} chrX chrY \
+		| tee >(bgzip -kc -@ $threads > "$genome.fa.gtf.gz") > "$genome.fa.gtf" | cat
+	[[ -x "$(command -v tabix)" ]] && tabix -f "$genome.fa.gtf.gz"
+
+	cat <<- EOF > "$genome.fa.gtf.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$url
+	EOF
+
+	return 0
+}
+
+################################################################################
+# DBSNP
+
+##### old sources. don't use v150/151 anymore and further, don't store as uncompressed vcf
+##### 151 gz is corrupt
+# url=$(curl -sl ftp://ftp.ncbi.nih.gov/snp/organisms/ | grep -E 'human_[0-9]+_b150_GRCh38' | sort -V | tail -1)
+
+# according to ncbi dbsnp 150 CAF info holds 1000genomes MAF only for REF and ALTs. from v151 on, common tagged from additional filtered by MAF>0.01
+# from v152 on there is no CAF anymore, but single project MAFs (see json files on ftp server)
+# ncbi 150: n=37463647 - ucsc says ncbi holds 38M common and 23M from 1000genomes. now apply MAF i.e. CAF filter.
+#           n=14851093   via bcftools view -H -i 'CAF[0]!~"^0\.99" && OTH=0 && CFL=0' GRCh38.fa.dbSNP150common.vcf.gz
+# ucsc 150: n=14375783   (https://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/snp150Common.txt.gz | awk '$2~/^chr[^_]+$/')
+
+##### new sources
+#####
+# ncbi 155: 21155945 - versus 14133245 common coming from ucsc always containing 1000Genomes (https://hgdownload.soe.ucsc.edu/gbdb/hg38/snp/dbSnp155Common.bb)
+#                      according to ucsc: ncbi has 15M variants with MAF>0.01 in the 1000Genomes Phase 3 dataset
+#           14203886   via bcftools view -H https://ftp.ncbi.nlm.nih.gov/snp/archive/b155/VCF/GCF_000001405.39.gz | grep -F 1000Genomes | perl -lane '$F[-1]=~/FREQ=([^;]+)/; @m=$1=~/:(0\.\d+)/g; print $_ if (sort {$a <=> $b} @m)[0]<=0.99'
+# ncbi 156: 21340526 -
+#           15194872   via .. analogous ..
+# embl 156: 82663547 - within 1000GENOMES-phase_3.vcf.gz -> some have MAF others ethnicity wise AF listed (africa, america, asia, europa, south-asia)
+#           15009538   via bcftools view -i '(MAF!="." && MAX(MAF)>0.01) || (MAF="." && (MAX(AFR)>0.01 || MAX(AMR)>0.01 || MAX(EAS)>0.01 || MAX(EUR)>0.01 || MAX(SAS)>0.01))'
+
+# ATTENTION ncbi and ensembl/ucsc dbsnp slightly differ at indel definitions
+# chr1 12345 id12345 AT ATT
+# chr1 12344 id12345  T  TT
+
+##### gatk bundles
+##### https://gatk.broadinstitute.org/hc/en-us/articles/360035890811-Resource-bundle
+# HG38
+# https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz
+# https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi
+# https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz
+# https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi
+## mutect germline-resource
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/af-only-gnomad.hg38.vcf.gz
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/af-only-gnomad.hg38.vcf.gz.tbi
+# ===> check out also https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/v4.1/genomes/
+## to check for contamination
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/small_exac_common_3.hg38.vcf.gz
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/small_exac_common_3.hg38.vcf.gz.tbi
+# ===> full exac here https://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/
+## pon
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/1000g_pon.hg38.vcf.gz
+# https://storage.googleapis.com/gatk-best-practices/somatic-hg38/1000g_pon.hg38.vcf.gz.tbi
+# HG19
+# https://storage.googleapis.com/gatk-legacy-bundles/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.gz
+# https://storage.googleapis.com/gatk-legacy-bundles/b37/1000G_phase1.snps.high_confidence.b37.vcf.gz
+## mutect germline-resource
+# https://storage.googleapis.com/gatk-best-practices/somatic-b37/af-only-gnomad.raw.sites.vcf
+## to check for contamination
+# https://storage.googleapis.com/gatk-best-practices/somatic-b37/small_exac_common_3.vcf
+## pon
+# https://storage.googleapis.com/gatk-best-practices/somatic-b37/Mutect2-WGS-panel-b37.vcf
+
+################################################################################
+
+alias dlgenome::hg19.dbsnp.gatk="_bashbone_wrapper dlgenome::hg19.dbsnp.gatk"
+function dlgenome::hg19.dbsnp.gatk() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading GATK SNP bundle"
+
+	tfile="$(mktemp -p "${TMPDIR:-/tmp}" XXXXXXXXXX.vcf.gz)"
+
+	url="https://storage.googleapis.com/gatk-legacy-bundles/b37/1000G_phase1.snps.high_confidence.b37.vcf.gz"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kcd -@ 1 | sed -E 's/\s+$//' | bgzip -kc -@ $threads > "$tfile"
+	tabix -f -p vcf "$tfile"
+	{	bcftools view -h "$tfile" 2> >(grep -v "PL should be declared" >&2 || true) | grep -vF -e '##contig='
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H "$tfile" $i 2> >(grep -v "PL should be declared" >&2 || true) | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" SNPs_gold.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" SNPs_gold.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-legacy-bundles/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.gz"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kcd -@ 1 | sed -E 's/\s+$//' | bgzip -kc -@ $threads > "$tfile"
+	tabix -f -p vcf "$tfile"
+	{	bcftools view -h "$tfile" | grep -vF -e '##contig='
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H "$tfile" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" InDel_gold.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" InDel_gold.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-b37/small_exac_common_3.vcf"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kc -@ $threads > "$tfile"
+	tabix -f -p vcf "$tfile"
+	{	bcftools view -h "$tfile" | grep -vF -e '##contig='
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H "$tfile" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url").gz"
+	tabix -f -p vcf "$(basename "$url").gz"
+	ln -sfnr "$(basename "$url").gz" ExAC_common.vcf.gz
+	ln -sfnr "$(basename "$url").gz.tbi" ExAC_common.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-b37/af-only-gnomad.raw.sites.vcf"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kc -@ $threads > "$tfile"
+	tabix -f -p vcf "$tfile"
+	{	bcftools view -h "$tfile" | grep -vF -e '##contig='
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H "$tfile" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url").gz"
+	tabix -f -p vcf "$(basename "$url").gz"
+	ln -sfnr "$(basename "$url").gz" gnomAD_with_AF.vcf.gz
+	ln -sfnr "$(basename "$url").gz.tbi" gnomAD_with_AF.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-b37/Mutect2-WGS-panel-b37.vcf"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kc -@ $threads > "$tfile"
+	tabix -f -p vcf "$tfile"
+	{	bcftools view -h "$tfile" | grep -vF -e '##contig='
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H "$tfile" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url").gz"
+	tabix -f -p vcf "$(basename "$url").gz"
+	ln -sfnr "$(basename "$url").gz" PON.vcf.gz
+	ln -sfnr "$(basename "$url").gz.tbi" PON.vcf.gz.tbi
+}
+
+alias dlgenome::hg19.dbsnp.ncbi="_bashbone_wrapper dlgenome::hg19.dbsnp.ncbi"
+function dlgenome::hg19.dbsnp.ncbi() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading dbSNP"
+
+	url="https://ftp.ncbi.nlm.nih.gov/snp/archive/"
+	url+="$(curl -s "$url" | grep -oE 'b[0-9]+' | sort -Vr | head -1)/VCF/"
+	url+="$(curl -s "$url" | grep -oE '[^">]+\.gz' | sort -V | head -1)"
+	# sort -V -> .25.vcf.gz -> hg19
+	# sort -Vr -> .[>30].vcf.gz -> hg38
+	version="$(bcftools view -h "$url" | grep -m 1 -F dbSNP_BUILD_ID | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')"
+	echo ":INFO: v$version from NCBI"
+
+	echo "rm -f '$(basename "$url")'*" >> "$BASHBONE_CLEANUP"
+	{	bcftools view -h "$url" | grep -vF '##contig='
+		for i in NC_012920.1 $(bcftools view -h "$url" | grep -F '##contig=' | grep -oE "NC_[^>]+" | grep -vF NC_012920.1 | sort -V); do
+			echo ":INFO: working on "$(sed -E 's/^NC_012920\S+/chrM/;t;s/^NC_000023\S+/chrX/;t;s/^NC_000024\S+/chrY/;t;s/^NC_000+([0-9]+)\.[0-9]+/chr\1/' <<< $i) >&2
+			bcftools view --threads $threads -H "$url" $i 2> >(grep -v "Extreme INFO" >&2 || true) | grep -F COMMON | grep -F 1000Genomes | sed -E 's/^NC_012920\S+/chrM/;t;s/^NC_000023\S+/chrX/;t;s/^NC_000024\S+/chrY/;t;s/^NC_000+([0-9]+)\.[0-9]+/chr\1/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		NCBI v$version $genome
+		COMMON only i.e. MAF > 0.01 and listed in 1000Genomes
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::hg19.dbsnp.ensembl="_bashbone_wrapper dlgenome::hg19.dbsnp.ensembl"
+function dlgenome::hg19.dbsnp.ensembl() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading dbSNP"
+	# last time listed under releases was 2021 -> v110 (https://ftp.ensembl.org/pub/grch37/release-110/variation/vcf/homo_sapiens/1000GENOMES-phase_3.vcf.gz)
+	url="https://ftp.ensembl.org/pub/grch37/variation/vcf/homo_sapiens/1000GENOMES-phase_3.vcf.gz"
+	version=$(bcftools view -h "$url" | grep -m 1 -oE dbSNP_[0-9]+ | cut -d _ -f 2)
+	echo ":INFO: v$version from Ensembl"
+
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" 2> >(grep -v "Invalid tag name" >&2 || true) | grep -vF -e '##contig=' -e "##INFO=<ID=HGMD-PUBLIC"
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -i '(MAF!="." && MAX(MAF)>0.01) || (MAF="." && (MAX(AFR)>0.01 || MAX(AMR)>0.01 || MAX(EAS)>0.01 || MAX(EUR)>0.01 || MAX(SAS)>0.01))' "$url" $i 2> >(grep -v "Invalid tag name" >&2 || true) | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		Ensembl v$version $genome
+		$url
+		common only i.e. MAF > 0.01 or if MAF absent one of populations > 0.01
+	EOF
+
+	return 0
+}
+
+alias dlgenome::hg19.dbsnp.ucsc="_bashbone_wrapper dlgenome::hg19.dbsnp.ucsc"
+function dlgenome::hg19.dbsnp.ucsc() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: ucsc dbsnp not supported"
+	# https://groups.google.com/a/soe.ucsc.edu/g/genome-announce/c/40coV6ZVtFY
+	# https://genome.ucsc.edu/cgi-bin/hgTrackUi?db=hg19&g=dbSnp155Composite
+	# http://hgdownload.soe.ucsc.edu/gbdb/hg19/snp/dbSnp155Common.bb
+
+	return 0
+}
+
+alias dlgenome::hg38.dbsnp.gatk="_bashbone_wrapper dlgenome::hg38.dbsnp.gatk"
+function dlgenome::hg38.dbsnp.gatk() {
+	cd "$outdir"
+	genome=GRCh38
+
+	echo ":INFO: downloading GATK SNP bundle"
+
+	url="https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+	{	bcftools view -h "$url" | grep -vF -e '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo ":INFO: working on $i" >&2
+			bcftools view --threads $threads -H "$url" $i
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" SNPs_gold.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" SNPs_gold.vcf.gz.tbi
+
+
+	# for BQSR also this can be supplied https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Homo_sapiens_assembly38.known_indels.vcf.gz
+	url="https://storage.googleapis.com/genomics-public-data/resources/broad/hg38/v0/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+	{	bcftools view -h "$url" | grep -vF -e '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo ":INFO: working on $i" >&2
+			bcftools view --threads $threads -H "$url" $i
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" InDel_gold.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" InDel_gold.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-hg38/small_exac_common_3.hg38.vcf.gz"
+	{	bcftools view -h "$url" | grep -vF -e '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo ":INFO: working on $i" >&2
+			bcftools view --threads $threads -H "$url" $i
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" ExAC_common.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" ExAC_common.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-hg38/af-only-gnomad.hg38.vcf.gz"
+	{	bcftools view -h "$url" | grep -vF -e '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo ":INFO: working on $i" >&2
+			bcftools view --threads $threads -H "$url" $i
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" gnomAD_with_AF.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" gnomAD_with_AF.vcf.gz.tbi
+
+
+	url="https://storage.googleapis.com/gatk-best-practices/somatic-hg38/1000g_pon.hg38.vcf.gz"
+	{	bcftools view -h "$url" | grep -vF -e '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo ":INFO: working on $i" >&2
+			bcftools view --threads $threads -H "$url" $i
+		done
+	} | bgzip -kc -@ $threads > "$(basename "$url")"
+	tabix -f -p vcf "$(basename "$url")"
+	ln -sfnr "$(basename "$url")" PON.vcf.gz
+	ln -sfnr "$(basename "$url").tbi" PON.vcf.gz.tbi
+}
+
+alias dlgenome::hg38.dbsnp.ncbi="_bashbone_wrapper dlgenome::hg38.dbsnp.ncbi"
+function dlgenome::hg38.dbsnp.ncbi() {
 	cd "$outdir"
 	genome=GRCh38
 
 	echo ":INFO: downloading dbSNP"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_variation/vcf/homo_sapiens/homo_sapiens-chr*.vcf.gz'
 
-	echo ":INFO: extracting dbSNP"
-	gzip -dc homo_sapiens-chrMT.vcf.gz | awk -F '\t' -v OFS='\t' '$1!~/^#/ && $NF~/^dbSNP/ {if($1=="MT"){$1="chrM"}else{$1="chr"$1} print}' > chrM.vcf
-	for i in {1..22} X Y; do
-		gzip -dc homo_sapiens-chr$i.vcf.gz | awk -F '\t' -v OFS='\t' '$1!~/^#/ && $NF~/^dbSNP/ {if($1=="MT"){$1="chrM"}else{$1="chr"$1} print}' > chr$i.vcf
-	done
+	url="https://ftp.ncbi.nlm.nih.gov/snp/archive/"
+	url+="$(curl -s "$url" | grep -oE 'b[0-9]+' | sort -Vr | head -1)/VCF/"
+	url+="$(curl -s "$url" | grep -oE '[^">]+\.gz' | sort -Vr | head -1)"
+	version="$(bcftools view -h "$url" | grep -m 1 -F dbSNP_BUILD_ID | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')"
+	echo ":INFO: v$version from NCBI"
+	# sort -V -> .25.vcf.gz -> hg19
+	# sort -Vr -> .[>30].vcf.gz -> hg38
 
-	echo ":INFO: sorting dbSNP"
-	gzip -dc homo_sapiens-chrMT.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	for i in M {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" | grep -vF '##contig='
+		for i in NC_012920.1 $(bcftools view -h "$url" | grep -F '##contig=' | grep -oE "NC_[^>]+" | grep -vF NC_012920.1 | sort -V); do
+			echo ":INFO: working on "$(sed -E 's/^NC_012920\S+/chrM/;t;s/^NC_000023\S+/chrX/;t;s/^NC_000024\S+/chrY/;t;s/^NC_000+([0-9]+)\.[0-9]+/chr\1/' <<< $i) >&2
+			bcftools view --threads $threads -H "$url" $i 2> >(grep -v "Extreme INFO" >&2 || true) | grep -F COMMON | grep -F 1000Genomes | sed -E 's/^NC_012920\S+/chrM/;t;s/^NC_000023\S+/chrX/;t;s/^NC_000024\S+/chrY/;t;s/^NC_000+([0-9]+)\.[0-9]+/chr\1/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
 
-	cat <<- EOF >> $genome.fa.vcf.README
+	cat <<- EOF >> "$genome.fa.vcf.README"
 		$(date)
 		$USER
-		Ensembl $genome $(grep -m 1 -Eo 'dbSNP_[0-9]+' $genome.fa.vcf | sed 's/_/ v\./')
-		ftp://ftp.ensembl.org/pub/current_variation/vcf/homo_sapiens/
+		NCBI v$version $genome
+		COMMON only i.e. MAF > 0.01 and listed in 1000Genomes
+		$url
 	EOF
 
-	rm -f homo_sapiens-chr*.vcf.gz
-	rm -f chr*.vcf
 	return 0
 }
 
-dlgenome::hg38.dbsnp.ncbi() {
+alias dlgenome::hg38.dbsnp.ensembl="_bashbone_wrapper dlgenome::hg38.dbsnp.ensembl"
+function dlgenome::hg38.dbsnp.ensembl() {
 	cd "$outdir"
 	genome=GRCh38
 
 	echo ":INFO: downloading dbSNP"
-	url=$(curl -sl ftp://ftp.ncbi.nih.gov/snp/organisms/ | grep -E 'human_[0-9]+_b[0-9]+_GRCh38' | sort -V | tail -1) # 151 gz is corrupt
+	# url="https://ftp.ensembl.org/pub/current_variation/vcf/homo_sapiens/1000GENOMES-phase_3.vcf.gz"
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/variation/vcf/homo_sapiens/1000GENOMES-phase_3.vcf.gz"
+	version="$(bcftools view -h "$url" | grep -m 1 -oE dbSNP_[0-9]+ | cut -d _ -f 2)"
+	echo ":INFO: v$version from Ensembl"
 
-	wget -c -q --show-progress  --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping ftp://ftp.ncbi.nih.gov/snp/organisms/$url/VCF/00-common_all.vcf.gz
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" 2> >(grep -v "Invalid tag name" >&2 || true) | grep -vF -e '##contig=' -e "##INFO=<ID=HGMD-PUBLIC"
+		for i in MT {1..22} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -i '(MAF!="." && MAX(MAF)>0.01) || (MAF="." && (MAX(AFR)>0.01 || MAX(AMR)>0.01 || MAX(EAS)>0.01 || MAX(EUR)>0.01 || MAX(SAS)>0.01))' "$url" $i 2> >(grep -v "Invalid tag name" >&2 || true) | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
 
-	echo ":INFO: extracting dbSNP"
-	gzip -dc 00-common_all.vcf.gz | perl -F'\t' -lane 'next if /^#/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.vcf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc 00-common_all.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	[[ -e chrM.vcf ]] && LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chrM.vcf >> $genome.fa.vcf
-	for i in {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
+	cat <<- EOF >> "$genome.fa.vcf.README"
 		$(date)
 		$USER
-		NCBI $genome $(grep -m 1 -F dbSNP_BUILD_ID $genome.fa.vcf | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')
-		ftp://ftp.ncbi.nih.gov/snp/organisms/$url/VCF/
+		Ensembl v$version $genome
+		common only i.e. MAF > 0.01 or if MAF absent one of populations > 0.01
+		$url
 	EOF
 
-	rm -f 00-common_all.vcf.gz
-	rm -f chr*.vcf
 	return 0
 }
 
-dlgenome::hg38.ctat() {
+alias dlgenome::hg38.dbsnp.ucsc="_bashbone_wrapper dlgenome::hg38.dbsnp.ucsc"
+function dlgenome::hg38.dbsnp.ucsc() {
+	cd "$outdir"
+	genome=GRCh38
+
+	echo ":INFO: ucsc dbsnp not supported"
+	return 0
+
+	# TODO needs more effort due to missing start position ref. see also
+	# https://groups.google.com/a/soe.ucsc.edu/g/genome/c/DIZVXERQnnk
+	# https://genome.ucsc.edu/cgi-bin/hgTrackUi?db=hg19&g=dbSnp155Composite
+	# e.g.
+	# vcf: chr1 1234 A AT
+	# bb:  chr1 1234 1234 "" "T"
+
+	# http://hgdownload.soe.ucsc.edu/gbdb/hg38/snp/dbSnp155Common.bb
+	url=$(curl -s "http://hgdownload.soe.ucsc.edu/gbdb/hg38/snp/" | grep -oE '[^">]+Common.bb' | sort -Vr | head -1)
+	url="http://hgdownload.soe.ucsc.edu/gbdb/hg38/snp/$url"
+	# wget -c -q --show-progress  --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping -O $genome.fa.bb "$url"
+	# needs dl first random access via url not possible
+	{	bcftools view -h "https://ftp.ncbi.nih.gov/snp/organisms/human_9606_b150_GRCh37p13/VCF/00-common_all.vcf.gz" | grep -vF '##contig='
+		for i in chrM chr{1..22} chrX chrY; do
+			echo "working on $i" >&2
+			bigBedToBed -chrom=$i "$genome.fa.bb" stdout | perl -lane '
+				print
+				@maf=split(/,/,$F[9]);
+				@alt_observed=split(/,/,$F[6]);
+				if ($#alt_observed == -1){
+					$x="deletion"
+					@alt_project=split(/,/,$F[10]);
+				} else {
+					@alt_project=split(/,/,$F[11]);
+				}
+			' | head
+		done
+	} #| bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	return
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	# for project order and description do
+	# curl -s "https://genome.ucsc.edu/cgi-bin/hgTables?db=hg38&hgta_group=varRep&hgta_track=dbSnp155Composite&hgta_table=dbSnp155&hgta_doSchema=describe+table+schema" | sed -n '/<ol>/,/<\/ol>/{p}' | grep 'href' | sed -E 's/^\s*//;:a;s/<[^>]+>//;ta;' | tr -s ' ' '_'
+	# remember: VCF position is bed start+1 coordiante
+	# chr1	11008	rs575272151	C	G	.	.	RS=575272151;RSPOS=11008;dbSNPBuildID=142;SSR=0;SAO=0;VP=0x050000020005150024000100;GENEINFO=DDX11L1:100287102;WGT=1;VC=SNV;R5;ASP;VLD;G5;KGPhase3;CAF=0.9119,0.08806;COMMON=1
+	# chr1	11007	11008	rs575272151	C	2	G,T,	0	31	0.0880591,8.43028e-05,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,-inf,	C,C,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,	G,T,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,	1986	snv	commonSome,rareSome,overlapDiffClass,	151778775275	194
+
+	# according to ucsc, MAF threshold is applied on any project reporting frequenies not just 1000genomes i.e. even some CAF[0]>0.99 are included
+	# ucsc bigbed has always 1000genomes MAF (first entry in list) and
+	# 1) sometimes more ALT than MAF listed
+	# 2) different MAF listed for same ALT and sometimes even REF
+	# 3) sometimes REF is minor and has to be excluded from ALT and CAF[0]=1000genomesMAF
+	# -> solve by extract from list, sort and report
+}
+
+alias dlgenome::mm10.dbsnp.gatk="_bashbone_wrapper dlgenome::mm10.dbsnp.gatk"
+function dlgenome::mm10.dbsnp.gatk() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: gatk bundle not available"
+	return 0
+}
+
+alias dlgenome::mm10.dbsnp.ncbi="_bashbone_wrapper dlgenome::mm10.dbsnp.ncbi"
+function dlgenome::mm10.dbsnp.ncbi() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: downloading dbSNP"
+	url="https://ftp.ncbi.nih.gov/snp/organisms/archive/mouse_10090/VCF/00-All.vcf.gz"
+	version="$(bcftools view -h "$url" | grep -m 1 -F dbSNP_BUILD_ID | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')"
+	echo ":INFO: v$version from NCBI"
+
+	# 81432271 -> 5570707 VLD validation tag
+	# likewise ucsc does for mm11, ncbi refers to EVA current_ids which needs to be filtered by validation tag RS_VALIDATED
+	# https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/
+
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" | grep -v '##contig='
+		for i in MT {1..19} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -i 'VLD=1' "$url" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		NCBI v$version $genome
+		filtered for VLD
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::mm10.dbsnp.ensembl="_bashbone_wrapper dlgenome::mm10.dbsnp.ensembl"
+function dlgenome::mm10.dbsnp.ensembl() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: ensembl dbsnp not supported"
+	return 0
+	url="https://ftp.ensembl.org/pub/release-102/variation/vcf/mus_musculus/mus_musculus.vcf.gz"
+	# contains 80M variants without any INFO on how to filter them
+}
+
+alias dlgenome::mm10.dbsnp.eva="_bashbone_wrapper dlgenome::mm10.dbsnp.eva"
+function dlgenome::mm10.dbsnp.eva() {
+	cd "$outdir"
+	genome=GRCm38
+
+	echo ":INFO: downloading dbSNP"
+	url="https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/"
+	version="$(curl -s "$url" | grep -oE 'release_[0-9]+' | sort -Vr | head -1)"
+	url+="$version/by_species/mus_musculus/"
+	url+="$(curl -s "$url" | grep -oE 'GRCm38.p[0-9]+' | sort -Vr | head -1)/"
+	url+="$(curl -s "$url" | grep -oE '[^"]+current_ids.vcf.gz' | head -1)"
+	echo ":INFO: v$(echo "$version" | cut -d _ -f 2 -) from EVA"
+
+	# likewise ucsc does for mm11, ncbi refers to EVA current_ids which needs to be filtered by validation tag RS_VALIDATED
+	# https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/
+	# 82691010 -> 5679799
+
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" | grep -v '##contig='
+		for i in MT {1..19} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -i 'RS_VALIDATED=1' "$url" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		EVA v"$(echo "$version" | cut -d _ -f 2 -)" $genome
+		filtered for RS_VALIDATED
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::mm10.dbsnp.ucsc="_bashbone_wrapper dlgenome::mm10.dbsnp.ucsc"
+function dlgenome::mm10.dbsnp.ucsc() {
+	cd "$outdir"
+	genome=GRCm38
+
+	tfile="$(mktemp -p "${TMPDIR:-/tmp}" snp142Common.XXXXXXXXXX.bed)"
+	echo ":INFO: downloading dbSNP"
+	url="https://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/snp142Common.txt.gz"
+	# echo "from NCBI v142 for filtering"
+	wget -O - -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "$url" | bgzip -kcd -@ 1 > "$tfile"
+
+	# url="https://ftp.ncbi.nih.gov/snp/organisms/archive/mouse_10090/VCF/00-All.vcf.gz"
+	# better use https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/GRCm38.p4/10090_GCA_000001635.6_current_ids.vcf.gz
+	# filter by UCSC common
+	# 81432271 -> 8404784 VLD using NCBI
+	# 82691010 -> 8592575 RS_VALIDATED using EVA
+
+	url="https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/"
+	url+="$(curl -s "$url" | grep -oE 'GRCm38.p[0-9]+' | sort -Vr | head -1)/"
+	url+="$(curl -s "$url/" | grep -oE '[^"]+current_ids.vcf.gz' | head -1)"
+	version="$(bcftools view -h "$url" | grep -m 1 -F dbSNP_BUILD_ID | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')"
+	echo ":INFO: v$version from UCSC"
+
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" | grep -v '##contig='
+		for i in MT {1..19} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -T <(awk -v i=$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) '$1==i' "$tfile" | sed 's/^chrM/MT/;t;s/^chr//') "$url" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		UCSC v$version $genome
+		filtered for https://hgdownload.cse.ucsc.edu/goldenPath/mm10/database/snp142Common.txt.gz
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::mm11.dbsnp.gatk="_bashbone_wrapper dlgenome::mm11.dbsnp.gatk"
+function dlgenome::mm11.dbsnp.gatk() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: gatk bundle not available"
+	return 0
+}
+
+alias dlgenome::mm11.dbsnp.ncbi="_bashbone_wrapper dlgenome::mm11.dbsnp.ncbi"
+function dlgenome::mm11.dbsnp.ncbi() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: ncbi dbsnp not available"
+	return 0
+}
+
+alias dlgenome::mm11.dbsnp.ensembl="_bashbone_wrapper dlgenome::mm11.dbsnp.ensembl"
+function dlgenome::mm11.dbsnp.ensembl() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: ensembl dbsnp not supported"
+	return 0
+
+	url="https://ftp.ensembl.org/pub/"
+	url+="$(curl -s "$url" | grep -oE 'release-[0-9]+' | sort -Vr | head -1)/variation/vcf/mus_musculus/mus_musculus.vcf.gz"
+	# contains 80M variants without any INFO on how to filter them
+}
+
+alias dlgenome::mm11.dbsnp.eva="_bashbone_wrapper dlgenome::mm11.dbsnp.eva"
+function dlgenome::mm11.dbsnp.eva() {
+	cd "$outdir"
+	genome=GRCm39
+	echo ":INFO: downloading dbSNP"
+
+	url="https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/"
+	version="$(curl -s "$url" | grep -oE 'release_[0-9]+' | sort -Vr | head -1)"
+	url+="$version/by_species/mus_musculus/GRCm39/"
+	url+="$(curl -s "$url" | grep -oE '[^"]+current_ids.vcf.gz' | head -1)"
+	echo ":INFO: v$(echo "$version" | cut -d _ -f 2-) from EVA"
+
+	echo "rm '$(basename "$url")'*" >> "$BASHBONE_CLEANUP" # bcftools fetches csi or tbi from server
+	{	bcftools view -h "$url" | grep -v '##contig='
+		for i in MT {1..19} X Y; do
+			echo ":INFO: working on "$(sed 's/^MT/chrM/;t;s/^/chr/' <<< $i) >&2
+			bcftools view --threads $threads -H -i 'RS_VALIDATED=1' "$url" $i | sed 's/^MT/chrM/;t;s/^/chr/'
+		done
+	} | bgzip -kc -@ $threads > "$genome.fa.vcf.gz"
+	tabix -f -p vcf "$genome.fa.vcf.gz"
+
+	cat <<- EOF >> "$genome.fa.vcf.README"
+		$(date)
+		$USER
+		EVA v"$(echo "$version" | cut -d _ -f 2-)" $genome
+		$url
+		filtered for RS_VALIDATED
+	EOF
+}
+
+alias dlgenome::mm11.dbsnp.ucsc="_bashbone_wrapper dlgenome::mm11.dbsnp.ucsc"
+function dlgenome::mm11.dbsnp.ucsc() {
+	cd "$outdir"
+	genome=GRCm39
+
+	echo ":INFO: ucsc dbsnp not supported"
+	return 0
+	# bigBedToBed https://hgdownload.soe.ucsc.edu/gbdb/mm39/bbi/evaSnp6.bb
+	# ucsc data source is eva
+	# https://ftp.ebi.ac.uk/pub/databases/eva/rs_releases/release_6/by_species/mus_musculus/GRCm39/10090_GCA_000001635.9_current_ids.vcf.gz
+}
+
+################################################################################
+# CTAT
+################################################################################
+
+alias dlgenome::hg19.ctat="_bashbone_wrapper dlgenome::hg19.ctat"
+function dlgenome::hg19.ctat() {
+	cd "$outdir"
+	genome=GRCh37
+
+	echo ":INFO: downloading CTAT"
+	url='https://data.broadinstitute.org/Trinity/CTAT_RESOURCE_LIB/'
+	url+="$(curl -sl "$url" | grep -oE 'GRCh37[^\"]+\.plug-n-play\.tar\.gz' | grep -v STAR | sort -Vr | head -1)"
+	version="$(basename "$url" .tar.gz | rev | cut -d _ -f 1 | rev)"
+	echo ":INFO: v$version from Broad Institute"
+
+	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url" | bgzip -kcd -@ 1 | tar -x
+	mv "$(basename "$url" .tar.gz)" "${genome}_CTAT_genome_lib"
+
+	cd "${genome}_CTAT_genome_lib"
+	cat <<- EOF >> "$genome.README"
+		$(date)
+		$USER
+		CTAT v$version $genome
+		$url
+	EOF
+
+	return 0
+}
+
+alias dlgenome::hg38.ctat="_bashbone_wrapper dlgenome::hg38.ctat"
+function dlgenome::hg38.ctat() {
 	cd "$outdir"
 	genome=GRCh38
 
 	echo ":INFO: downloading CTAT"
+
 	url='https://data.broadinstitute.org/Trinity/CTAT_RESOURCE_LIB/'
-	file=$(curl -sl $url | grep -E 'GRCh38[^\"]+\.plug-n-play\.tar\.gz' | sort -Vr | head -1)
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url$file"
+	url+="$(curl -sl "$url" | grep -oE 'GRCh38[^\"]+\.plug-n-play\.tar\.gz' | grep -v STAR | sort -Vr | head -1)"
+	version="$(basename "$url" .tar.gz | rev | cut -d _ -f 1 | rev)"
+	echo ":INFO: v$version from Broad Institute"
 
-	echo ":INFO: extracting CTAT"
-	tar -xzf $file
-	rm -f $file
-	mv $(basename $file .tar.gz) ${genome}_CTAT_genome_lib
+	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url" | bgzip -kcd -@ 1 | tar -x
+	mv "$(basename "$url" .tar.gz)" "${genome}_CTAT_genome_lib"
 
-	cd ${genome}_CTAT_genome_lib
-	cat <<- EOF >> $genome.README
+	cd "${genome}_CTAT_genome_lib"
+	cat <<- EOF >> "$genome.README"
 		$(date)
 		$USER
-		CTAT $genome $(basename $file .plug-n-play.tar.gz)
+		CTAT v$version $genome
 		$url
 	EOF
 
-	rm -f $file
-
 	return 0
 }
 
-##########
-#  hg19  #
-##########
-
-dlgenome::hg19.genome() {
+alias dlgenome::mm10.ctat="_bashbone_wrapper dlgenome::mm10.ctat"
+function dlgenome::mm10.ctat() {
 	cd "$outdir"
-	genome=GRCh37
+	genome=GRCm38
 
-	echo ":INFO: downloading $genome genome"
-	wget -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/Homo_sapiens.GRCh37.dna.chromosome.*.fa.gz'
-
-	echo ":INFO: extracting genome"
-	gzip -dc Homo_sapiens.GRCh37.dna.chromosome.MT.fa.gz | sed "s/>.*/>chrM/" > $genome.fa
-	for i in {1..22} X Y; do
-		gzip -dc Homo_sapiens.GRCh37.dna.chromosome.$i.fa.gz | sed "s/>.*/>chr$i/" >> $genome.fa
-	done
-
-	ensembl=$(ls -v Homo_sapiens.GRCh37.dna.chromosome.*.fa.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.README
-		$(date)
-		$USER
-		Ensembl $genome genome
-		ftp://ftp.ensembl.org/pub/grch37/current/fasta/homo_sapiens/dna/
-	EOF
-
-	rm -f Homo_sapiens.GRCh37.dna.chromosome.*.fa.gz
+	echo ":INFO: CTAT not available anymore"
 	return 0
 }
 
-dlgenome::hg19.gtf() {
-	cd "$outdir"
-	genome=GRCh37
-
-	echo ":INFO: downloading annotation"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/Homo_sapiens.GRCh37.*.chr.gtf.gz'
-
-	echo ":INFO: extracting annotation"
-	gzip -dc Homo_sapiens.GRCh37.*.chr.gtf.gz | perl -F'\t' -lane 'next unless $F[0]=~/^(\d+|X|Y|MT)$/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.gtf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting annotation"
-	rm -f $genome.fa.gtf
-	for i in M {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k4,4n -k5,5n chr$i.gtf >> $genome.fa.gtf
-	done
-
-	ensembl=$(ls -v Homo_sapiens.GRCh37.*.chr.gtf.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.gtf.README
-		$(date)
-		$USER
-		Ensembl $genome gtf v$ensembl
-		ftp://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/
-	EOF
-
-	rm -f Homo_sapiens.GRCh37.*.chr.gtf.gz
-	rm -f chr*.gtf
-	return 0
-}
-
-dlgenome::hg19.dbsnp.ensembl() {
-	cd "$outdir"
-	genome=GRCh37
-
-	echo ":INFO: downloading dbSNP"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/grch37/current/variation/vcf/homo_sapiens/homo_sapiens-chr*.vcf.gz'
-
-	echo ":INFO: extracting dbSNP"
-	gzip -dc homo_sapiens-chrMT.vcf.gz | awk -F '\t' -v OFS='\t' '$1!~/^#/ && $NF~/^dbSNP/ {if($1=="MT"){$1="chrM"}else{$1="chr"$1} print}' > chrM.vcf
-	for i in {1..22} X Y; do
-		gzip -dc homo_sapiens-chr$i.vcf.gz | awk -F '\t' -v OFS='\t' '$1!~/^#/ && $NF~/^dbSNP/ {if($1=="MT"){$1="chrM"}else{$1="chr"$1} print}' > chr$i.vcf
-	done
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc homo_sapiens-chrMT.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	for i in M {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
-		$(date)
-		$USER
-		Ensembl $genome $(grep -m 1 -Eo 'dbSNP_[0-9]+' $genome.fa.vcf | sed 's/_/ v\./')
-		ftp://ftp.ensembl.org/pub/grch37/current/variation/vcf/homo_sapiens/
-	EOF
-
-	rm -f homo_sapiens-chr*.vcf.gz
-	rm -f chr*.vcf
-	return 0
-}
-
-dlgenome::hg19.dbsnp.ncbi() {
-	cd "$outdir"
-	genome=GRCh37
-
-	echo ":INFO: downloading dbSNP"
-	url=$(curl -sl ftp://ftp.ncbi.nih.gov/snp/organisms/ | grep -E 'human_[0-9]+_b[0-9]+_GRCh37' | sort -V | tail -1)
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping "ftp://ftp.ncbi.nih.gov/snp/organisms/$url/VCF/00-common_all.vcf.gz"
-
-	echo ":INFO: extracting dbSNP"
-	gzip -dc 00-common_all.vcf.gz | perl -F'\t' -lane 'next if /^#/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.vcf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc 00-common_all.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	[[ -e chrM.vcf ]] && LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chrM.vcf >> $genome.fa.vcf
-	for i in {1..22} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
-		$(date)
-		$USER
-		NCBI $genome $(grep -m 1 -F dbSNP_BUILD_ID $genome.fa.vcf | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')
-		ftp://ftp.ncbi.nih.gov/snp/organisms/$url/VCF/
-	EOF
-
-	rm -f 00-common_all.vcf.gz
-	rm -f chr*.vcf
-	return 0
-}
-
-dlgenome::hg19.ctat() {
-	cd "$outdir"
-	genome=GRCh37
-
-	echo ":INFO: downloading CTAT"
-	url='https://data.broadinstitute.org/Trinity/CTAT_RESOURCE_LIB/'
-	file=$(curl -sl $url | grep -E 'GRCh37[^\"]+\.plug-n-play\.tar\.gz' | sort -Vr | head -1)
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url$file"
-
-	echo ":INFO: extracting CTAT"
-	tar -xzf $file
-	rm -f $file
-	mv $(basename $file .tar.gz) ${genome}_CTAT_genome_lib
-
-	cd ${genome}_CTAT_genome_lib
-	cat <<- EOF >> $genome.README
-		$(date)
-		$USER
-		CTAT $genome $(basename $file .plug-n-play.tar.gz)
-		$url
-	EOF
-
-	rm -f $file
-	return 0
-}
-
-##########
-#  mm11  #
-##########
-
-dlgenome::mm11.genome() {
-	cd "$outdir"
-	genome=GRCm39
-
-	echo ":INFO: downloading $genome genome"
-	wget -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_fasta/mus_musculus/dna/Mus_musculus.GRCm39.dna.chromosome.*.fa.gz'
-
-	echo ":INFO: extracting genome"
-	gzip -dc Mus_musculus.GRCm39.dna.chromosome.MT.fa.gz | sed "s/>.*/>chrM/" > $genome.fa
-	for i in {1..19} X Y; do
-		gzip -dc Mus_musculus.GRCm39.dna.chromosome.$i.fa.gz | sed "s/>.*/>chr$i/" >> $genome.fa
-	done
-
-	ensembl=$(ls -v Mus_musculus.GRCm39.dna.chromosome.*.fa.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.README
-		$(date)
-		$USER
-		Ensembl $genome genome
-		ftp://ftp.ensembl.org/pub/current_fasta/mus_musculus/dna/
-	EOF
-
-	rm -f Mus_musculus.GRCm39.dna.chromosome.*.fa.gz
-	return 0
-}
-
-dlgenome::mm11.gtf() {
-	cd "$outdir"
-	genome=GRCm39
-
-	echo ":INFO: downloading annotation"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_gtf/mus_musculus/Mus_musculus.GRCm39.*.chr.gtf.gz'
-
-	echo ":INFO: extracting annotation"
-	gzip -dc Mus_musculus.GRCm39.*.chr.gtf.gz | perl -F'\t' -lane 'next unless $F[0]=~/^(\d+|X|Y|MT)$/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.gtf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting annotation"
-	rm -f $genome.fa.gtf
-	for i in M {1..19} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k4,4n -k5,5n chr$i.gtf >> $genome.fa.gtf
-	done
-
-	ensembl=$(ls -v Mus_musculus.GRCm39.*.chr.gtf.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.gtf.README
-		$(date)
-		$USER
-		Ensembl $genome gtf v$ensembl
-		ftp://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/
-	EOF
-
-	rm -f Mus_musculus.GRCm39.*.chr.gtf.gz
-	rm -f chr*.gtf
-	return 0
-}
-
-dlgenome::mm11.dbsnp.ensembl() {
-	cd "$outdir"
-	genome=GRCm39
-
-	echo ":INFO: downloading dbSNP"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_variation/vcf/mus_musculus/mus_musculus.vcf.gz'
-
-	echo ":INFO: extracting dbSNP"
-	# as of v109 no dbsnp annotation in vcf
-	gzip -dc mus_musculus.vcf.gz | perl -F'\t' -lane 'next if /^#/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.vcf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc mus_musculus.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	[[ -e chrM.vcf ]] && LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chrM.vcf >> $genome.fa.vcf
-	for i in {1..19} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
-		$(date)
-		$USER
-		Ensembl $genome $(grep -m 1 -Eo 'dbSNP_[0-9]+' $genome.fa.vcf | sed 's/_/ v\./')
-		ftp://ftp.ensembl.org/pub/current_variation/vcf/mus_musculus/
-	EOF
-
-	rm -f mus_musculus.vcf.gz
-	rm -f chr*.vcf
-	return 0
-}
-
-dlgenome::mm11.dbsnp.ncbi() {
-	cd "$outdir"
-	genome=GRCm39
-
-	echo ":INFO: ncbi dbsnp not (yet?) available"
-	return 0
-}
-
-dlgenome::mm11.ctat() {
+alias dlgenome::mm11.ctat="_bashbone_wrapper dlgenome::mm11.ctat"
+function dlgenome::mm11.ctat() {
 	cd "$outdir"
 	genome=GRCm39
 
 	echo ":INFO: downloading CTAT"
 	url='https://data.broadinstitute.org/Trinity/CTAT_RESOURCE_LIB/'
-	file=$(curl -sl $url | grep -E 'Mouse_GRCm39[^\"]+\.plug-n-play\.tar\.gz' | sort -Vr | head -1)
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url$file"
+	url+="$(curl -s "$url" | grep -oE 'Mouse_GRCm39[^\"]+\.plug-n-play\.tar\.gz' | grep -v STAR | sort -Vr | head -1)"
+	version="$(basename "$url" .tar.gz | rev | cut -d _ -f 1 | rev)"
+	echo ":INFO: v$version from Broad Institute"
 
-	echo ":INFO: extracting CTAT"
-	tar -xzf $file
-	rm -f $file
-	mv $(basename $file .tar.gz) ${genome}_CTAT_genome_lib
+	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused "$url" | bgzip -kcd -@ 1 | tar -x
+	mv "$(basename "$url" .tar.gz)" "${genome}_CTAT_genome_lib"
 
-	cd ${genome}_CTAT_genome_lib
-	cat <<- EOF >> $genome.README
+	cd "${genome}_CTAT_genome_lib"
+	cat <<- EOF >> "$genome.README"
 		$(date)
 		$USER
-		CTAT $genome $(basename $file .plug-n-play.tar.gz)
+		CTAT v$version $genome
 		$url
 	EOF
 
-	rm -f $file
 	return 0
 }
 
-##########
-#  mm10  #
-##########
-
-dlgenome::mm10.genome() {
-	cd "$outdir"
-	genome=GRCm38
-
-	echo ":INFO: downloading $genome genome"
-	wget -c -q --show-progress --progress=bar:force --timeout=60 --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/release-102/fasta/mus_musculus/dna/Mus_musculus.GRCm38.dna.chromosome.*.fa.gz'
-
-	echo ":INFO: extracting genome"
-	gzip -dc Mus_musculus.GRCm38.dna.chromosome.MT.fa.gz | sed "s/>.*/>chrM/" > $genome.fa
-	for i in {1..19} X Y; do
-		gzip -dc Mus_musculus.GRCm38.dna.chromosome.$i.fa.gz | sed "s/>.*/>chr$i/" >> $genome.fa
-	done
-
-	ensembl=$(ls -v Mus_musculus.GRCm38.dna.chromosome.*.fa.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.README
-		$(date)
-		$USER
-		Ensembl $genome genome
-		ftp://ftp.ensembl.org/pub/current_fasta/mus_musculus/dna/
-	EOF
-
-	rm -f Mus_musculus.GRCm38.dna.chromosome.*.fa.gz
-	return 0
-}
-
-dlgenome::mm10.gtf() {
-	cd "$outdir"
-	genome=GRCm38
-
-	echo ":INFO: downloading annotation"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/release-102/gtf/mus_musculus/Mus_musculus.GRCm38.*.chr.gtf.gz'
-
-	echo ":INFO: extracting annotation"
-	gzip -dc Mus_musculus.GRCm38.*.chr.gtf.gz | perl -F'\t' -lane 'next unless $F[0]=~/^(\d+|X|Y|MT)$/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.gtf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting annotation"
-	rm -f $genome.fa.gtf
-	for i in M {1..19} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k4,4n -k5,5n chr$i.gtf >> $genome.fa.gtf
-	done
-
-	ensembl=$(ls -v Mus_musculus.GRCm38.*.chr.gtf.gz | tail -1 | grep -Eo '\.[0-9]+')
-	cat <<- EOF > $genome.fa.gtf.README
-		$(date)
-		$USER
-		Ensembl $genome gtf v$ensembl
-		ftp://ftp.ensembl.org/pub/grch37/current/gtf/homo_sapiens/
-	EOF
-
-	rm -f Mus_musculus.GRCm38.*.chr.gtf.gz
-	rm -f chr*.gtf
-	return 0
-}
-
-dlgenome::mm10.dbsnp.ensembl() {
-	cd "$outdir"
-	genome=GRCm38
-
-	echo ":INFO: downloading dbSNP"
-	# wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/current_variation/vcf/mus_musculus/mus_musculus.vcf.gz'
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping --glob=on 'ftp://ftp.ensembl.org/pub/release-102/variation/vcf/mus_musculus/mus_musculus.vcf.gz'
-
-	echo ":INFO: extracting dbSNP"
-	gzip -dc mus_musculus.vcf.gz | perl -F'\t' -lane 'next if /^#/ || $F[-1]!~/^dbSNP/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.vcf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc mus_musculus.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	[[ -e chrM.vcf ]] && LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chrM.vcf >> $genome.fa.vcf
-	for i in {1..19} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
-		$(date)
-		$USER
-		Ensembl $genome $(grep -m 1 -Eo 'dbSNP_[0-9]+' $genome.fa.vcf | sed 's/_/ v\./')
-		ftp://ftp.ensembl.org/pub/current_variation/vcf/mus_musculus/
-	EOF
-
-	rm -f mus_musculus.vcf.gz
-	rm -f chr*.vcf
-	return 0
-}
-
-dlgenome::mm10.dbsnp.ncbi() {
-	cd "$outdir"
-	genome=GRCm38
-
-	echo ":INFO: downloading dbSNP"
-	wget -c -q --show-progress --progress=bar:force --waitretry=10 --tries=10 --retry-connrefused --timestamping 'ftp://ftp.ncbi.nih.gov/snp/organisms/archive/mouse_10090/VCF/00-All.vcf.gz'
-
-	echo ":INFO: extracting dbSNP"
-	gzip -dc 00-All.vcf.gz | perl -F'\t' -lane 'next if /^#/; $F[0]="M" if $F[0] eq "MT"; $F[0]="chr$F[0]"; unless($f eq $F[0]){close O; $f=$F[0]; open O,">$f.vcf";} print O join("\t",@F); END{close O};'
-
-	echo ":INFO: sorting dbSNP"
-	gzip -dc 00-All.vcf.gz | head -1000 | grep '^#' > $genome.fa.vcf
-	[[ -e chrM.vcf ]] && LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chrM.vcf >> $genome.fa.vcf
-	for i in {1..19} X Y; do
-		LC_ALL=C sort -S 1000M -T "${TMPDIR:-/tmp}" --parallel=$threads -k2,2n chr$i.vcf >> $genome.fa.vcf
-	done
-
-	cat <<- EOF >> $genome.fa.vcf.README
-		$(date)
-		$USER
-		NCBI $genome $(grep -m 1 -F dbSNP_BUILD_ID $genome.fa.vcf | sed -E 's/.*(dbSNP)_BUILD_ID=(.+)/\1 v.\2/')
-		ftp://ftp.ncbi.nih.gov/snp/organisms/archive/mouse_10090/VCF/
-	EOF
-
-	rm -f 00-All.vcf.gz
-	rm -f chr*.vcf
-	return 0
-}
-
-dlgenome::mm10.ctat() {
-	cd "$outdir"
-	genome=GRCm38
-
-	echo ":INFO: ctat not available anymore"
-	return 0
-}
-
-############# MAIN #############
+################################################################################
+# MAIN
+################################################################################
 
 checkopt() {
 	local arg=false
 	case $1 in
 		-h | --h | -help | --help) { usage || exit 0; };;
 		-t | --t | -threads | --threads) arg=true; threads=$2;;
-		-o | --o | -out | --out) arg=true; outdir=$2;;
+		-o | --o | -out | --out) arg=true; outdir="$2";;
 		-r | --r | -reference | --reference) arg=true; ref=$2;;
 		-g | --g | -genome | --genome) fun+=("genome");;
 		-c | --c | -ctat | --ctat) fun+=("ctat");;
 		-a | --a | -annotation | --annotation) fun+=("gtf");;
 		-s | --s | -dbsnp | --dbsnp) db="ensembl";;
 		-n | --n | -ncbi | --ncbi) db='ncbi';;
+		-u | --u | -ucsc | --ucsc) db='ucsc';;
+		-k | --k | -gatk | --gatk) db='gatk';;
 		-d | --d | -descriptions | --descriptions) godb="ensembl";;
 		-m | --m | -msigdb | --msigdb) godb="msigdb";;
 		-e | --e | -enrichr | --enrichr) godb="enrichr";;
@@ -1086,14 +1519,17 @@ for i in $(seq 1 $#); do
 		((++i))
 	fi
 done
-[[ $db ]] && fun+=("dbsnp.$db")
-[[ $godb ]] && fun+=("go")
 BASHBONE_ERROR="mandatory parameter -r missing"
 [[ $ref ]]
+if [[ $db ]]; then
+	[[ "$db" == "ensembl" && $ref == mm* ]] && db="eva"
+	fun+=("dbsnp.$db")
+fi
+[[ $godb ]] && fun+=("go")
 outdir="${outdir:-$PWD}"
 BASHBONE_ERROR="cannot create $outdir"
 mkdir -p "$outdir"
-outdir="$(readlink -e "$outdir")"
+outdir="$(realpath -se "$outdir")"
 log="$outdir/dlgenome.log"
 rm -f "$log"
 BASHBONE_ERROR="cannot create $log"
@@ -1101,7 +1537,7 @@ touch "$log"
 
 for f in "${fun[@]}"; do
 	BASHBONE_ERROR="dlgenome::$ref.$f failed"
-	dlgenome::$ref.$f 2>&1 | tee -ai "$log"
+	eval dlgenome::$ref.$f 2>&1 | tee -ai "$log"
 done
 echo ":INFO: success" | tee -ai "$log"
 

--- a/scripts/fpkm.pl
+++ b/scripts/fpkm.pl
@@ -42,7 +42,7 @@ while(<F>){
 	$l[-1]=~/transcript_id\s+(\S+)/;
 	my $t = $1 ? $1 : 'transcript';
 	$t=~s/("|;)//g;
-	if ($l[-1]=~/tag\s+\"(CCDS|\S+_canonical)\"/) {
+	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
 	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {
 		$m{$g}{2}{$t} += $l[4]-$l[3]+1;

--- a/scripts/fpkm.pl
+++ b/scripts/fpkm.pl
@@ -21,9 +21,10 @@ use feature ":5.10";
 use List::Util qw(min max);
 
 if ($#ARGV < 3){
-	say "usage: tpm.pl file.gtf feature-level feature-tag htseq.counts";
-	say "gtf needs to contain feature level e.g. exon to be summarized";
-	say "and feature id tag e.g. gene_id with optional transcript_id";
+	say "usage: fpkm.pl <gtf> <feature-level> <feature-tag> <htseq.counts>";
+	say 'extracts canonical transcripts searching for flags CCDS/*canonical, fallbacks to the longest meta-feature composed of sub-transcript features given the associated <feature-level> e.g. "exon"';
+	say 'for each canonical transcript, the parental feature of interest is looked-up by its <feature-tag> e.g. "gene_id" or "gene_name" within the first column of supplied <htseq.counts> file';
+	say 'the count value stored in the second column gets normalized by total count (library size) and canonical or longest transcript length';
 	exit 1;
 }
 
@@ -40,8 +41,7 @@ while(<F>){
 	my $g = $1 ? $1 : $l[-1];
 	$g=~s/("|;)//g;
 	$l[-1]=~/transcript_id\s+(\S+)/;
-	my $t = $1 ? $1 : 'transcript';
-	$t=~s/("|;)//g;
+	my $t = $1 ? $1=~s/("|;)//gr : 'transcript';
 	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
 	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {

--- a/scripts/tpm.pl
+++ b/scripts/tpm.pl
@@ -42,7 +42,7 @@ while(<F>){
 	$l[-1]=~/transcript_id\s+(\S+)/;
 	my $t = $1 ? $1 : 'transcript';
 	$t=~s/("|;)//g;
-	if ($l[-1]=~/tag\s+\"(CCDS|\S+_canonical)\"/) {
+	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
 	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {
 		$m{$g}{2}{$t} += $l[4]-$l[3]+1;

--- a/scripts/tpm.pl
+++ b/scripts/tpm.pl
@@ -21,9 +21,10 @@ use feature ":5.10";
 use List::Util qw(min max);
 
 if ($#ARGV < 3){
-	say "usage: tpm.pl file.gtf feature-level feature-tag htseq.counts";
-	say "gtf needs to contain feature level e.g. exon to be summarized";
-	say "and feature id tag e.g. gene_id with optional transcript_id";
+	say "usage: tpm.pl <gtf> <feature-level> <feature-tag> <htseq.counts>";
+	say 'extracts canonical transcripts searching for flags CCDS/*canonical, fallbacks to the longest meta-feature composed of sub-transcript features given the associated <feature-level> e.g. "exon"';
+	say 'for each canonical transcript, the parental feature of interest is looked-up by its <feature-tag> e.g. "gene_id" or "gene_name" within the first column of supplied <htseq.counts> file';
+	say 'the count value stored in the second column gets normalized by total count (library size) and canonical or longest transcript length';
 	exit 1;
 }
 
@@ -40,8 +41,7 @@ while(<F>){
 	my $g = $1 ? $1 : $l[-1];
 	$g=~s/("|;)//g;
 	$l[-1]=~/transcript_id\s+(\S+)/;
-	my $t = $1 ? $1 : 'transcript';
-	$t=~s/("|;)//g;
+	my $t = $1 ? $1=~s/("|;)//gr : 'transcript';
 	if ($l[-1]=~/tag\s+\"(CCDS|[^"]*canonical)\"/) {
 		$m{$g}{1}{$t} += $l[4]-$l[3]+1;
 	} elsif ($l[2] eq 'ensembl_havana' || $l[2] eq 'HAVANA') {

--- a/scripts/volcano.R
+++ b/scripts/volcano.R
@@ -74,13 +74,11 @@ if(is.na(args[3])){
   }
 
   topidx = head(which(! is.na(df$padj) & df$padj<0.05),n=ndowns)
-  got=topidx
   df[topidx,]$label = df[topidx,]$name
   topidx = tail(which(! is.na(df$padj) & df$padj<0.05),n=nups)
-  got=unique(c(got,topidx))
   df[topidx,]$label = df[topidx,]$name
   df = df[order(df$padj,na.last = T),]
-  topidx = head(which(! df$id %in% df$id[got] & ! is.na(df$padj) & df$padj<0.05),n=10)
+  topidx = head(which(is.na(df$label) & ! is.na(df$padj) & df$padj<0.05),n=10)
   df[topidx,]$label = df[topidx,]$name
 } else {
   idlist = scan(args[3], character(), quote="", quiet=T)
@@ -95,14 +93,11 @@ if(is.na(args[3])){
   }
 
   topidx = head(which(df$id %in% idlist & ! is.na(df$padj) & df$padj<0.05),n=ndowns)
-  got=topidx
   df[topidx,]$label = df[topidx,]$name
   topidx = tail(which(df$id %in% idlist & ! is.na(df$padj) & df$padj<0.05),n=nups)
-  got=unique(c(got,topidx))
   df[topidx,]$label = df[topidx,]$name
   df = df[order(df$padj,na.last = T),]
-  topidx = head(which(! df$id %in% df$id[got] & df$id %in% idlist & ! is.na(df$padj) & df$padj<0.05),n=10)
-
+  topidx = head(which(is.na(df$label) & df$id %in% idlist & ! is.na(df$padj) & df$padj<0.05),n=10)
   df[topidx,]$label = df[topidx,]$name
 }
 ups=sum(!is.na(df$padj) & df$padj<0.05 & df$log2FoldChange > 0)
@@ -120,7 +115,7 @@ ggplot(df, aes(x=log2FoldChange, y=-log10(pvalue), col=Regulation, label=label))
   geom_point(alpha=0.65) + 
   theme_classic() +
   # scale_color_manual(values=c("blue","darkgrey","red","#00c200")) +
-  scale_color_manual(values=c("Down" = "blue", "n.s." = "darkgrey", "Up" = "red", "highlight" = "#00c200"), breaks=c("Down","NA","Up")) +
+  scale_color_manual(values=c("Down" = "blue", "n.s." = "darkgrey", "Up" = "red", "highlight" = "#00c200"), breaks=c("Down","n.s.","Up")) +
   geom_vline(xintercept=c(-0.5, 0.5), col="black", linetype="longdash") +
   geom_hline(yintercept=-log10(0.05), col="black", linetype="longdash") +
   ggtitle(title) +


### PR DESCRIPTION
function improvements
- peak calling (min widths, further optimized for cut&tag, up/down sampling bam for spikein normalization)
- variant calling (speedup and padding)
- BS methylation rates inference (haarz on bwa, methyldackel on segemehl)
- multijoin (fixed)
- vcf and bam indices are now created on the fly
- improved UMI representation in bam
- slicing (fixed if no. seq <= threads)
re-worked dlgenome
